### PR TITLE
Separate objects from storing global variables

### DIFF
--- a/jvm/src/main/scala/me/shadaj/scalapy/py/JepInterpreter.scala
+++ b/jvm/src/main/scala/me/shadaj/scalapy/py/JepInterpreter.scala
@@ -36,6 +36,13 @@ class JepInterpreter extends Interpreter {
   def valueFromDouble(v: Double): PyValue = valueFromJepAny(v)
   def valueFromString(v: String): PyValue = valueFromJepAny(v)
 
+  def valueFromSeq(seq: Seq[PyValue]): PyValue = {
+    valueFromJepAny(seq.view.map {
+      case v: JepJavaPyValue => v.value
+      case v: JepPythonPyValue => v.pyObject
+    }.toArray)
+  }
+
   def noneValue: PyValue = valueFromJepAny(null)
 
   val stringifiedNone = underlying.getValue("str(None)", classOf[String])
@@ -124,6 +131,8 @@ class JepJavaPyValue(val value: Any) extends JepPyValue {
   }
 
   def getStringified = if (value == null) interpreter.stringifiedNone else value.toString()
+
+  def cleanup() = {}
 }
 
 class JepPythonPyValue(val pyObject: PyObject) extends JepPyValue {
@@ -134,4 +143,6 @@ class JepPythonPyValue(val pyObject: PyObject) extends JepPyValue {
   }
 
   def getStringified = if (pyObject == null) interpreter.stringifiedNone else pyObject.toString()
+
+  def cleanup() = {}
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.7")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.8")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 

--- a/shared/src/main/scala/me/shadaj/scalapy/py/DynamicObject.scala
+++ b/shared/src/main/scala/me/shadaj/scalapy/py/DynamicObject.scala
@@ -2,7 +2,7 @@ package me.shadaj.scalapy.py
 
 import scala.language.dynamics
 
-class DynamicObject private[py](varId: Int) extends Object(varId) with scala.Dynamic {
+class DynamicObject(value: PyValue) extends Object(value) with scala.Dynamic {
   def applyDynamic(method: String)(params: Object*): DynamicObject = {
     Object(s"$expr.$method(${params.map(_.expr).mkString(",")})").asInstanceOf[DynamicObject]
   }

--- a/shared/src/main/scala/me/shadaj/scalapy/py/Global.scala
+++ b/shared/src/main/scala/me/shadaj/scalapy/py/Global.scala
@@ -4,11 +4,11 @@ import scala.language.dynamics
 
 class Global private[py]() extends scala.Dynamic {
   def applyDynamic(method: String)(params: Object*): Object = {
-    Object(s"$method(${params.map(_.expr).mkString(",")})")
+    Object(s"$method(${params.map(_.expr.variable).mkString(",")})")
   }
 
   def applyDynamicNamed(method: String)(params: (String, Object)*): DynamicObject = {
-    Object(s"$method(${params.map(t => s"${t._1} = ${t._2.expr}").mkString(",")})").asInstanceOf[DynamicObject]
+    Object(s"$method(${params.map(t => s"${t._1} = ${t._2.expr.variable}").mkString(",")})").asInstanceOf[DynamicObject]
   }
 
   def selectDynamic(value: String): Object = {

--- a/shared/src/main/scala/me/shadaj/scalapy/py/Interpreter.scala
+++ b/shared/src/main/scala/me/shadaj/scalapy/py/Interpreter.scala
@@ -1,12 +1,26 @@
 package me.shadaj.scalapy.py
 
 class VariableReference(val variable: String) {
-  override def toString(): String = variable
-  // todo cleanup
+  if (VariableReference.allocatedReferences.nonEmpty) {
+    VariableReference.allocatedReferences = (this :: VariableReference.allocatedReferences.head) :: VariableReference.allocatedReferences.tail
+  } else if (Platform.isNative) {
+    println(s"Warning: the reference $variable was allocated into a global space, which means it will not be garbage collected in Scala Native")
+  }
 
-  override def finalize(): Unit = {
+  override def toString(): String = variable
+
+  def cleanup(): Unit = {
     interpreter.eval(s"del $variable")
   }
+
+  override def finalize(): Unit = {
+    cleanup()
+  }
+}
+
+object VariableReference {
+  import scala.collection.mutable
+  private[py] var allocatedReferences: List[List[VariableReference]] = List.empty
 }
 
 trait Interpreter {
@@ -21,12 +35,18 @@ trait Interpreter {
   def valueFromLong(v: Long): PyValue
   def valueFromDouble(v: Double): PyValue
   def valueFromString(v: String): PyValue
-  // def valueFromSeq(elements: Seq[PyValue]): PyValue
+  def valueFromSeq(elements: Seq[PyValue]): PyValue
 
   def noneValue: PyValue
 }
 
 trait PyValue {
+  if (PyValue.allocatedValues.nonEmpty) {
+    PyValue.allocatedValues = (this :: PyValue.allocatedValues.head) :: PyValue.allocatedValues.tail
+  } else if (Platform.isNative) {
+    println(s"Warning: the value ${this.getStringified} was allocated into a global space, which means it will not be garbage collected in Scala Native")
+  }
+
   def getString: String
   def getLong: Long
   def getDouble: Double
@@ -38,4 +58,13 @@ trait PyValue {
 
   import scala.collection.mutable
   def getMap: mutable.Map[PyValue, PyValue]
+
+  def cleanup(): Unit
+
+  override def finalize(): Unit = cleanup()
+}
+
+object PyValue {
+  import scala.collection.mutable
+  private[py] var allocatedValues: List[List[PyValue]] = List.empty
 }

--- a/shared/src/main/scala/me/shadaj/scalapy/py/Interpreter.scala
+++ b/shared/src/main/scala/me/shadaj/scalapy/py/Interpreter.scala
@@ -1,15 +1,27 @@
 package me.shadaj.scalapy.py
 
+class VariableReference(val variable: String) {
+  override def toString(): String = variable
+  // todo cleanup
+
+  override def finalize(): Unit = {
+    interpreter.eval(s"del $variable")
+  }
+}
+
 trait Interpreter {
   def eval(string: String): Unit
   def set(string: String, value: PyValue): Unit
 
   def load(variable: String): PyValue
 
+  def getVariableReference(value: PyValue): VariableReference
+
   def valueFromBoolean(v: Boolean): PyValue
   def valueFromLong(v: Long): PyValue
   def valueFromDouble(v: Double): PyValue
   def valueFromString(v: String): PyValue
+  // def valueFromSeq(elements: Seq[PyValue]): PyValue
 
   def noneValue: PyValue
 }
@@ -21,6 +33,8 @@ trait PyValue {
   def getBoolean: Boolean
   def getTuple: Seq[PyValue]
   def getSeq: Seq[PyValue]
+
+  def getStringified: String
 
   import scala.collection.mutable
   def getMap: mutable.Map[PyValue, PyValue]

--- a/shared/src/main/scala/me/shadaj/scalapy/py/Object.scala
+++ b/shared/src/main/scala/me/shadaj/scalapy/py/Object.scala
@@ -15,18 +15,12 @@ class Object(val value: PyValue) { self =>
 
   private var cleaned = false
 
-  if (Object.allocatedObjects.nonEmpty) {
-    Object.allocatedObjects.head += this
-  } else if (Platform.isNative) {
-    println(s"Warning: the object $this was allocated into a global space, which means it will not be garbage collected in Scala Native")
-  }
-
   override def toString: String = value.getStringified
 
   override def finalize(): Unit = {
     if (!cleaned) {
       if (_expr != null) {
-        _expr.finalize()
+        _expr.cleanup()
       }
 
       cleaned = true
@@ -40,7 +34,6 @@ class Object(val value: PyValue) { self =>
 
 object Object {
   private var nextCounter: Int = 0
-  private[py] var allocatedObjects: List[mutable.Queue[Object]] = List.empty
 
   def apply(stringToEval: String): Object = {
     populateWith(interpreter.load(stringToEval))

--- a/shared/src/main/scala/me/shadaj/scalapy/py/Object.scala
+++ b/shared/src/main/scala/me/shadaj/scalapy/py/Object.scala
@@ -3,31 +3,37 @@ package me.shadaj.scalapy.py
 import scala.language.dynamics
 import scala.collection.mutable
 
-class Object(val variableId: Int) { self =>
-  final val expr = s"spy_o_$variableId"
+class Object(val value: PyValue) { self =>
+  private var _expr: VariableReference = null
+  def expr = {
+    if (_expr == null) {
+      _expr = interpreter.getVariableReference(value)
+    }
+
+    _expr
+  }
 
   private var cleaned = false
 
   if (Object.allocatedObjects.nonEmpty) {
     Object.allocatedObjects.head += this
-  }/* else if (isNative) {
+  } else if (Platform.isNative) {
     println(s"Warning: the object $this was allocated into a global space, which means it will not be garbage collected in Scala Native")
-  }*/
-
-  def value: PyValue = interpreter.load(expr)
-
-  override def toString: String = {
-    interpreter.load(s"str($expr)").getString
   }
+
+  override def toString: String = value.getStringified
 
   override def finalize(): Unit = {
     if (!cleaned) {
-      interpreter.eval(s"del $expr")
+      if (_expr != null) {
+        _expr.finalize()
+      }
+
       cleaned = true
     }
   }
 
-  def as[T: ObjectReader]: T = implicitly[ObjectReader[T]].read(new ValueAndRequestObject(interpreter.load(expr)) {
+  def as[T: ObjectReader]: T = implicitly[ObjectReader[T]].read(new ValueAndRequestObject(interpreter.load(expr.variable)) {
     override def getObject: Object = self
   })
 }
@@ -36,37 +42,12 @@ object Object {
   private var nextCounter: Int = 0
   private[py] var allocatedObjects: List[mutable.Queue[Object]] = List.empty
 
-  def empty: Object = {
-    val variableName = nextCounter
-    nextCounter += 1
-
-    new DynamicObject(variableName)
-  }
-
   def apply(stringToEval: String): Object = {
-    val variableName = nextCounter
-    nextCounter += 1
-
-    interpreter.eval(s"spy_o_$variableName = $stringToEval")
-
-    new DynamicObject(variableName)
-  }
-
-  /**
-   * Constructs a Python value by populating a generated variable, usually via Jep calls.
-   * @param populateVariable a function that populates a variable given its name and the Jep instance
-   */
-  def apply(populateVariable: String => Unit): Object = {
-    val ret = Object.empty
-    populateVariable(ret.expr)
-    
-    ret
+    populateWith(interpreter.load(stringToEval))
   }
 
   def populateWith(v: PyValue): Object = {
-    apply { variable =>
-      interpreter.set(variable, v)
-    }
+    new DynamicObject(v)
   }
 
   implicit def from[T](v: T)(implicit writer: ObjectWriter[T]): Object = {

--- a/shared/src/main/scala/me/shadaj/scalapy/py/ObjectFacade.scala
+++ b/shared/src/main/scala/me/shadaj/scalapy/py/ObjectFacade.scala
@@ -3,7 +3,7 @@ package me.shadaj.scalapy.py
 import scala.reflect.macros.whitebox
 import scala.language.experimental.macros
 
-class ObjectFacade(originalObject: Object) extends Object(originalObject.variableId) {
+class ObjectFacade(originalObject: Object) extends Object(originalObject.value) {
   final val toObject = originalObject
   final val toDynamic = originalObject.asInstanceOf[DynamicObject]
 

--- a/shared/src/main/scala/me/shadaj/scalapy/py/ObjectReader.scala
+++ b/shared/src/main/scala/me/shadaj/scalapy/py/ObjectReader.scala
@@ -21,17 +21,17 @@ trait ObjectReader[T] {
 
 object ObjectReader extends ObjectTupleReaders {
   implicit val wrapperReader = new ObjectReader[Object] {
-    def read(r: ValueAndRequestObject): Object = new DynamicObject(r.requestObject.variableId)
+    def read(r: ValueAndRequestObject): Object = new DynamicObject(r.requestObject.value)
   }
 
   implicit val wrapperDynReader = new ObjectReader[DynamicObject] {
     def read(r: ValueAndRequestObject): DynamicObject =
-      new DynamicObject(r.requestObject.variableId)
+      new DynamicObject(r.requestObject.value)
   }
 
   implicit def facadeReader[F <: ObjectFacade](implicit classTag: ClassTag[F]): ObjectReader[F] = new ObjectReader[F] {
     override def read(r: ValueAndRequestObject): F = {
-      classTag.runtimeClass.getConstructor(classOf[Object]).newInstance(new DynamicObject(r.requestObject.variableId)).asInstanceOf[F]
+      classTag.runtimeClass.getConstructor(classOf[Object]).newInstance(new DynamicObject(r.requestObject.value)).asInstanceOf[F]
     }
   }
 

--- a/shared/src/main/scala/me/shadaj/scalapy/py/package.scala
+++ b/shared/src/main/scala/me/shadaj/scalapy/py/package.scala
@@ -30,16 +30,22 @@ package object py {
     ret
   }
 
-  def local(f: => Unit): Unit = {
-    py.Object.allocatedObjects = mutable.Queue.empty[py.Object] :: py.Object.allocatedObjects
-    f
+  def local[T](f: => T): T = {
+    py.PyValue.allocatedValues = List.empty[PyValue] :: py.PyValue.allocatedValues
+    py.VariableReference.allocatedReferences = List.empty[VariableReference] :: py.VariableReference.allocatedReferences
+    val ret: T = f
 
-    val toClean = py.Object.allocatedObjects.head
-
-    toClean.foreach { c =>
-      c.finalize()
+    py.PyValue.allocatedValues.head.foreach { c =>
+      c.cleanup()
     }
 
-    py.Object.allocatedObjects = py.Object.allocatedObjects.tail
+    py.VariableReference.allocatedReferences.head.foreach { c =>
+      c.cleanup()
+    }
+
+    py.PyValue.allocatedValues = py.PyValue.allocatedValues.tail
+    py.VariableReference.allocatedReferences = py.VariableReference.allocatedReferences.tail
+
+    ret
   }
 }

--- a/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
+++ b/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
@@ -8,18 +8,24 @@ class StringObjectFacade(obj: Object) extends ObjectFacade(obj) {
 
 class MethodCallingTest extends FunSuite with BeforeAndAfterAll {
   test("Can access global variables") {
-    val obj = Object("123")
-    assert(global.selectDynamic(obj.expr.variable).as[Int] == 123)
+    local {
+      val obj = Object("123")
+      assert(global.selectDynamic(obj.expr.variable).as[Int] == 123)
+    }
   }
 
   test("Can call global len with Scala sequence") {
-    assert(global.len(Seq(1, 2, 3)).as[Int] == 3)
+    local {
+      assert(global.len(Seq(1, 2, 3)).as[Int] == 3)
+    }
   }
 
   test("Can call dynamic + on integers") {
-    val num1 = Object("1")
-    val num2 = Object("2")
-    assert((num1.asInstanceOf[DynamicObject] + num2).as[Int] == 3)
+    local {
+      val num1 = Object("1")
+      val num2 = Object("2")
+      assert((num1.asInstanceOf[DynamicObject] + num2).as[Int] == 3)
+    }
   }
 
   if (!Platform.isNative) {
@@ -29,11 +35,13 @@ class MethodCallingTest extends FunSuite with BeforeAndAfterAll {
   }
 
   test("Can use with statement with file object") {
-    val opened = if (Platform.isNative) {
-      global.open("./README.md", "r")
-     } else global.open("../README.md", "r")
-    `with`(opened) { file =>
-      assert(file.asInstanceOf[DynamicObject].encoding.as[String] == "UTF-8")
+    local {
+      val opened = if (Platform.isNative) {
+        global.open("./README.md", "r")
+      } else global.open("../README.md", "r")
+      `with`(opened) { file =>
+        assert(file.asInstanceOf[DynamicObject].encoding.as[String] == "UTF-8")
+      }
     }
   }
 }

--- a/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
+++ b/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
@@ -9,7 +9,7 @@ class StringObjectFacade(obj: Object) extends ObjectFacade(obj) {
 class MethodCallingTest extends FunSuite with BeforeAndAfterAll {
   test("Can access global variables") {
     val obj = Object("123")
-    assert(global.selectDynamic(obj.expr).as[Int] == 123)
+    assert(global.selectDynamic(obj.expr.variable).as[Int] == 123)
   }
 
   test("Can call global len with Scala sequence") {

--- a/shared/src/test/scala/me/shadaj/scalapy/py/ModuleTest.scala
+++ b/shared/src/test/scala/me/shadaj/scalapy/py/ModuleTest.scala
@@ -8,7 +8,9 @@ class StringModuleFacade(o: Object) extends ObjectFacade(o) {
 
 class ModuleTest extends FunSuite with BeforeAndAfterAll {
   test("Can read value from module") {
-    assert(module("string").digits.as[String] == "0123456789")
+    local {
+      assert(module("string").digits.as[String] == "0123456789")
+    }
   }
 
   if (!Platform.isNative) {

--- a/shared/src/test/scala/me/shadaj/scalapy/py/ObjectReaderTest.scala
+++ b/shared/src/test/scala/me/shadaj/scalapy/py/ObjectReaderTest.scala
@@ -4,72 +4,104 @@ import org.scalatest.{FunSuite, BeforeAndAfterAll}
 
 class ObjectReaderTest extends FunSuite with BeforeAndAfterAll {
   test("Reading a boolean") {
-    assert(Object.from(false).as[Boolean] == false)
-    assert(Object.from(true).as[Boolean] == true)
+    local {
+      assert(Object.from(false).as[Boolean] == false)
+      assert(Object.from(true).as[Boolean] == true)
+    }
   }
 
   test("Reading a byte") {
-    assert(Object.from(5.toByte).as[Byte] == 5.toByte)
+    local {
+      assert(Object.from(5.toByte).as[Byte] == 5.toByte)
+    }
   }
 
   test("Reading an integer") {
-    assert(Object.from(123).as[Int] == 123)
+    local {
+      assert(Object.from(123).as[Int] == 123)
+    }
   }
 
   test("Reading a long") {
-    assert(Object.from(Long.MaxValue).as[Long] == Long.MaxValue)
+    local {
+      assert(Object.from(Long.MaxValue).as[Long] == Long.MaxValue)
+    }
   }
 
   test("Reading a float") {
-    assert(Object.from(123.123f).as[Float] == 123.123f)
+    local {
+      assert(Object.from(123.123f).as[Float] == 123.123f)
+    }
   }
 
   test("Reading a double") {
-    assert(Object.from(123.123d).as[Double] == 123.123d)
+    local {
+      assert(Object.from(123.123d).as[Double] == 123.123d)
+    }
   }
 
   test("Reading a string") {
-    assert(Object.from("hello world!").as[String] == "hello world!")
+    local {
+      assert(Object.from("hello world!").as[String] == "hello world!")
+    }
   }
 
   test("Reading an empty sequence") {
-    assert(Object.from(Seq.empty[Int]).as[Seq[Int]].isEmpty)
+    local {
+      assert(Object.from(Seq.empty[Int]).as[Seq[Int]].isEmpty)
+    }
   }
 
   test("Reading a sequence of ints") {
-    assert(Object.from(Seq[Int](1, 2, 3)).as[Seq[Int]] == Seq(1, 2, 3))
+    local {
+      assert(Object.from(Seq[Int](1, 2, 3)).as[Seq[Int]] == Seq(1, 2, 3))
+    }
   }
 
   test("Reading a sequence of doubles") {
-    assert(Object.from(Seq[Double](1.1, 2.2, 3.3)).as[Seq[Double]] == Seq(1.1, 2.2, 3.3))
+    local {
+      assert(Object.from(Seq[Double](1.1, 2.2, 3.3)).as[Seq[Double]] == Seq(1.1, 2.2, 3.3))
+    }
   }
 
   test("Reading a sequence of strings") {
-    assert(Object.from(Seq[String]("hello", "world")).as[Seq[String]] == Seq("hello", "world"))
+    local {
+      assert(Object.from(Seq[String]("hello", "world")).as[Seq[String]] == Seq("hello", "world"))
+    }
   }
 
   test("Reading a sequence of arrays") {
-    assert(Object.from(Seq[Array[Int]](Array(1), Array(2))).as[Seq[Seq[Int]]] == Seq(Seq(1), Seq(2)))
+    local {
+      assert(Object.from(Seq[Array[Int]](Array(1), Array(2))).as[Seq[Seq[Int]]] == Seq(Seq(1), Seq(2)))
+    }
   }
 
   test("Reading a sequence of sequences") {
-    assert(Object.from(Seq[Seq[Int]](Seq(1), Seq(2))).as[Seq[Seq[Int]]] == Seq(Seq(1), Seq(2)))
+    local {
+      assert(Object.from(Seq[Seq[Int]](Seq(1), Seq(2))).as[Seq[Seq[Int]]] == Seq(Seq(1), Seq(2)))
+    }
   }
 
   test("Reading a sequence of objects preserves original object") {
-    val datetimeExpr = module("datetime").moduleName
-    val datesSeq = Object(s"[$datetimeExpr.date.today(), $datetimeExpr.date.today().replace(year = 1000)]").as[Seq[Object]]
-    assert(datesSeq.head.asInstanceOf[DynamicObject].year.as[Int] > 2000)
-    assert(datesSeq.last.asInstanceOf[DynamicObject].year.as[Int] == 1000)
+    local {
+      val datetimeExpr = module("datetime").moduleName
+      val datesSeq = Object(s"[$datetimeExpr.date.today(), $datetimeExpr.date.today().replace(year = 1000)]").as[Seq[Object]]
+      assert(datesSeq.head.asInstanceOf[DynamicObject].year.as[Int] > 2000)
+      assert(datesSeq.last.asInstanceOf[DynamicObject].year.as[Int] == 1000)
+    }
   }
 
   test("Reading a map of int to int") {
-    val read = Object.from(Map(1 -> 2, 2 -> 3)).as[Map[Int, Int]]
-    assert(read(1) == 2)
-    assert(read(2) == 3)
+    local {
+      val read = Object.from(Map(1 -> 2, 2 -> 3)).as[Map[Int, Int]]
+      assert(read(1) == 2)
+      assert(read(2) == 3)
+    }
   }
 
   test("Reading a tuple") {
-    assert(Object.from((1, 2)).as[(Int, Int)] == (1, 2))
+    local {
+      assert(Object.from((1, 2)).as[(Int, Int)] == (1, 2))
+    }
   }
 }

--- a/shared/src/test/scala/me/shadaj/scalapy/py/ObjectWriterTest.scala
+++ b/shared/src/test/scala/me/shadaj/scalapy/py/ObjectWriterTest.scala
@@ -77,7 +77,7 @@ class ObjectWriterTest extends FunSuite with BeforeAndAfterAll {
 
   test("Writing a sequence of Python objects preserves original objects") {
     val objectsExpr = Object.from(Seq[Object](Object("object()"), Object("object()"))).expr
-    assert(interpreter.load(s"str(type($objectsExpr[0]))").getString == "<class 'object'>")
+    assert(interpreter.load(s"type($objectsExpr[0])").getStringified == "<class 'object'>")
   }
 
   test("Writing a map of int to int") {

--- a/shared/src/test/scala/me/shadaj/scalapy/py/ObjectWriterTest.scala
+++ b/shared/src/test/scala/me/shadaj/scalapy/py/ObjectWriterTest.scala
@@ -8,65 +8,95 @@ import scala.collection.JavaConverters._
 
 class ObjectWriterTest extends FunSuite with BeforeAndAfterAll {
   test("Writing a none value") {
-    assert(Object.from(None).toString == "None") // make sure it is actually a Python `None`
+    local {
+      assert(Object.from(None).toString == "None") // make sure it is actually a Python `None`
+    }
   }
 
   test("Writing a boolean") {
-    assert(Object.from(false).value.getBoolean == false)
-    assert(Object.from(true).value.getBoolean == true)
+    local {
+      assert(Object.from(false).value.getBoolean == false)
+      assert(Object.from(true).value.getBoolean == true)
+    }
   }
 
   test("Writing a byte") {
-    assert(Object.from(5.toByte).value.getLong == 5.toByte)
+    local {
+      assert(Object.from(5.toByte).value.getLong == 5.toByte)
+    }
   }
 
   test("Writing an integer") {
-    assert(Object.from(123).value.getLong == 123)
+    local {
+      assert(Object.from(123).value.getLong == 123)
+    }
   }
 
   test("Writing a long") {
-    assert(Object.from(Long.MaxValue).value.getLong == Long.MaxValue)
+    local {
+      assert(Object.from(Long.MaxValue).value.getLong == Long.MaxValue)
+    }
   }
 
   test("Writing a float") {
-    assert(Object.from(123.123f).value.getDouble == 123.123f)
+    local {
+      assert(Object.from(123.123f).value.getDouble == 123.123f)
+    }
   }
 
   test("Writing a double") {
-    assert(Object.from(123.123d).value.getDouble == 123.123d)
+    local {
+      assert(Object.from(123.123d).value.getDouble == 123.123d)
+    }
   }
 
   test("Writing a string") {
-    assert(Object.from("hello world!").value.getString == "hello world!")
+    local {
+      assert(Object.from("hello world!").value.getString == "hello world!")
+    }
   }
 
   test("Writing a union") {
-    assert(Object.from("hello world!": String | Int).value.getString == "hello world!")
-    assert(Object.from(123: String | Int).value.getLong == 123)
+    local {
+      assert(Object.from("hello world!": String | Int).value.getString == "hello world!")
+      assert(Object.from(123: String | Int).value.getLong == 123)
+    }
   }
 
   test("Writing an empty sequence") {
-    assert(Object.from(Seq.empty[Int]).value.getSeq.length == 0)
+    local {
+      assert(Object.from(Seq.empty[Int]).value.getSeq.length == 0)
+    }
   }
 
   test("Writing a sequence of ints") {
-    assert(Object.from(Seq[Int](1, 2, 3)).value.getSeq.map(_.getLong) == Seq(1, 2, 3))
+    local {
+      assert(Object.from(Seq[Int](1, 2, 3)).value.getSeq.map(_.getLong) == Seq(1, 2, 3))
+    }
   }
 
   test("Writing a sequence of doubles") {
-    assert(Object.from(Seq[Double](1.1, 2.2, 3.3)).value.getSeq.map(_.getDouble) == Seq(1.1, 2.2, 3.3))
+    local {
+      assert(Object.from(Seq[Double](1.1, 2.2, 3.3)).value.getSeq.map(_.getDouble) == Seq(1.1, 2.2, 3.3))
+    }
   }
 
   test("Writing a sequence of strings") {
-    assert(Object.from(Seq[String]("hello", "world")).value.getSeq.map(_.getString) == Seq("hello", "world"))
+    local {
+      assert(Object.from(Seq[String]("hello", "world")).value.getSeq.map(_.getString) == Seq("hello", "world"))
+    }
   }
 
   test("Writing a sequence of arrays") {
-    assert(Object.from(Seq[Array[Int]](Array(1), Array(2))).value.getSeq.map(_.getSeq.map(_.getLong)) == Seq(Seq(1), Seq(2)))
+    local {
+      assert(Object.from(Seq[Array[Int]](Array(1), Array(2))).value.getSeq.map(_.getSeq.map(_.getLong)) == Seq(Seq(1), Seq(2)))
+    }
   }
 
   test("Writing a sequence of sequences") {
-    assert(Object.from(Seq[Seq[Int]](Seq(1), Seq(2))).value.getSeq.map(_.getSeq.map(_.getLong)) == Seq(Seq(1), Seq(2)))
+    local {
+      assert(Object.from(Seq[Seq[Int]](Seq(1), Seq(2))).value.getSeq.map(_.getSeq.map(_.getLong)) == Seq(Seq(1), Seq(2)))
+    }
   }
 
   if (!Platform.isNative) {
@@ -76,18 +106,24 @@ class ObjectWriterTest extends FunSuite with BeforeAndAfterAll {
   }
 
   test("Writing a sequence of Python objects preserves original objects") {
-    val objectsExpr = Object.from(Seq[Object](Object("object()"), Object("object()"))).expr
-    assert(interpreter.load(s"type($objectsExpr[0])").getStringified == "<class 'object'>")
+    local {
+      val objectsExpr = Object.from(Seq[Object](Object("object()"), Object("object()"))).expr
+      assert(interpreter.load(s"type($objectsExpr[0])").getStringified == "<class 'object'>")
+    }
   }
 
   test("Writing a map of int to int") {
-    val written = Object.from(Map(1 -> 2, 2 -> 3)).value.getMap
-    assert(written(interpreter.valueFromLong(1)).getLong == 2)
-    assert(written(interpreter.valueFromLong(2)).getLong == 3)
+    local {
+      val written = Object.from(Map(1 -> 2, 2 -> 3)).value.getMap
+      assert(written(interpreter.valueFromLong(1)).getLong == 2)
+      assert(written(interpreter.valueFromLong(2)).getLong == 3)
+    }
   }
 
   test("Writing a tuple") {
-    val tupleValue = Object.from((1, 2)).value
-    assert(tupleValue.getTuple.map(_.getLong) == Seq(1, 2))
+    local {
+      val tupleValue = Object.from((1, 2)).value
+      assert(tupleValue.getTuple.map(_.getLong) == Seq(1, 2))
+    }
   }
 }


### PR DESCRIPTION
No need to generate global variables on native, and somewhat also on JVM.