### PR TITLE
Update to latest scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val scalaPy =
       Seq(fileToWrite)
     }
   ).settings(
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.0-SNAP10" % Test
+    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0-SNAP8" % Test
   ).jvmSettings(
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     libraryDependencies += "black.ninia" % "jep" % "3.8.2",


### PR DESCRIPTION
As far as I understand, scalatest abandoned the 3.2 branch and is working on the 3.1 branch. The lastest crossplatform artifact on maven is 3.1.0-SNAP8 (from 13/03/2019).