### PR TITLE
Upgrade to scalanative 0.4.0-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,16 +86,16 @@ lazy val core = crossProject(JVMPlatform, NativePlatform)
       Seq(fileToWrite)
     }
   ).settings(
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0-SNAP8" % Test,
+    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0-RC2" % Test,
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
   ).jvmSettings(
     libraryDependencies += "net.java.dev.jna" % "jna" % "5.4.0",
-    libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
+    libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
     fork in Test := true,
     javaOptions in Test += s"-Djna.library.path=${"python3-config --prefix".!!.trim}/lib"
   ).nativeSettings(
     scalaVersion := "2.11.12",
-    libraryDependencies += "com.github.lolgab" %%% "scalacheck" % "1.14.1" % Test,
+    libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.1" % Test,
     nativeLinkStubs := true,
     nativeLinkingOptions ++= "python3-config --ldflags".!!.split(' ').map(_.trim).filter(_.nonEmpty).toSeq
   )

--- a/core/native/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
@@ -2,8 +2,6 @@ package me.shadaj.scalapy.py
 
 import scala.scalanative.unsafe._
 import scala.scalanative.annotation._
-import scala.scalanative.unsigned._
-import scala.scalanative.libc._
 
 @extern
 object CPythonAPI {

--- a/core/native/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
@@ -1,6 +1,9 @@
 package me.shadaj.scalapy.py
 
-import scala.scalanative.native._
+import scala.scalanative.unsafe._
+import scala.scalanative.annotation._
+import scala.scalanative.unsigned._
+import scala.scalanative.libc._
 
 @extern
 object CPythonAPI {
@@ -53,7 +56,7 @@ object CPythonAPI {
   def PyObject_GetAttrString(obj: Platform.Pointer, name: CString): Platform.Pointer = extern
   def PyObject_SetAttr(obj: Platform.Pointer, name: Platform.Pointer, newValue: Platform.Pointer): Platform.Pointer = extern
   def PyObject_SetAttrString(obj: Platform.Pointer, name: CString, newValue: Platform.Pointer): Platform.Pointer = extern
-  def PyObject_CallMethodObjArgs(obj: Platform.Pointer, name: Platform.Pointer, args: CVararg*): Platform.Pointer = extern
+  def PyObject_CallMethodObjArgs(obj: Platform.Pointer, name: Platform.Pointer, args: CVarArg*): Platform.Pointer = extern
   def PyObject_Call(obj: Platform.Pointer, args: Platform.Pointer, kwArgs: Platform.Pointer): Platform.Pointer = extern
 
   def PyErr_Occurred(): Platform.Pointer = extern

--- a/core/native/src/main/scala/me/shadaj/scalapy/py/Platform.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/py/Platform.scala
@@ -1,38 +1,37 @@
 package me.shadaj.scalapy.py
 
-import scala.scalanative.{native => sn}
-import scala.scalanative.native.Ptr
+import scala.scalanative.{unsafe => snu}
+import scala.scalanative.unsafe.{Ptr, CQuote}
 import java.nio.charset.Charset
-import scala.scalanative.native.CQuote
 
 object Platform {
   final val isNative = true
 
-  def Zone[T](fn: sn.Zone => T): T = sn.Zone(fn)
+  def Zone[T](fn: snu.Zone => T): T = snu.Zone(fn)
 
   def fromCString(ptr: Pointer, charset: Charset): String = {
-    sn.fromCString(ptr, charset)
+    snu.fromCString(ptr, charset)
   }
 
-  def toCString(str: String, charset: Charset = Charset.defaultCharset())(implicit zone: sn.Zone): CString = sn.toCString(str, charset)
+  def toCString(str: String, charset: Charset = Charset.defaultCharset())(implicit zone: snu.Zone): CString = snu.toCString(str, charset)
 
   val emptyCString: CString = c""
 
-  type CString = sn.CString
+  type CString = snu.CString
   type Pointer = Ptr[Byte]
   type PointerToPointer = Ptr[Ptr[Byte]]
 
-  def allocPointerToPointer(implicit zone: sn.Zone): PointerToPointer = {
-    sn.alloc[Ptr[Byte]]
+  def allocPointerToPointer(implicit zone: snu.Zone): PointerToPointer = {
+    snu.alloc[Ptr[Byte]]
   }
 
   def pointerToLong(pointer: Pointer): Long = {
-    pointer.cast[Long]
+    pointer.toLong
   }
 
-  def cLongToLong(cLong: sn.CLong): Long = cLong
+  def cLongToLong(cLong: snu.CLong): Long = cLong
 
-  def intToCLong(int: Int): sn.CLong = int
+  def intToCLong(int: Int): snu.CLong = int
 
   def dereferencePointerToPointer(pointer: PointerToPointer): Pointer = !pointer
 }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
@@ -80,7 +80,7 @@ object CPythonInterpreter {
   }
 
   def throwErrorIfOccured() = {
-    if (Platform.pointerToLong(CPythonAPI.PyErr_Occurred()) != 0) {
+    if (CPythonAPI.PyErr_Occurred() != null) {
       Platform.Zone { implicit zone =>
         val pType = Platform.allocPointerToPointer
         val pValue = Platform.allocPointerToPointer

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.8")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.0-M2")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.1")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.0-M2")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")


### PR DESCRIPTION
This PR upgrades ScalaPy to use [Scala Native 0.4.0-M2](https://github.com/scala-native/scala-native/releases/tag/v0.4.0-M2) which is particularly attractive as it removes the dependency on `re2`.