### PR TITLE
Add tests for raising Python exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 website/build
 website/node_modules
 *.bench.txt
+lowered.hnir

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ErrorTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ErrorTest.scala
@@ -1,8 +1,9 @@
 package me.shadaj.scalapy.py
 
-import org.scalatest.FunSuite
+import org.scalatest.{FunSuite, BeforeAndAfterAll}
 
-class ErrorTest extends FunSuite {
+
+class ErrorTest extends FunSuite with BeforeAndAfterAll {
   test("Gets exception when running Python fails") {
     local {
       assertThrows[PythonException] {

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ErrorTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ErrorTest.scala
@@ -3,6 +3,14 @@ package me.shadaj.scalapy.py
 import org.scalatest.FunSuite
 
 class ErrorTest extends FunSuite {
+  test("Gets exception when running Python fails") {
+    local {
+      assertThrows[PythonException] {
+        py"123[0]"
+      }
+    }
+  }
+
   test("Throwing a SyntaxError") {
     local {
       val exp = intercept[PythonException](py"(1 2)")

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ErrorTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ErrorTest.scala
@@ -1,0 +1,27 @@
+package me.shadaj.scalapy.py
+
+import org.scalatest.FunSuite
+
+class ErrorTest extends FunSuite {
+  test("Throwing a SyntaxError") {
+    local {
+      val exp = intercept[PythonException](py"(1 2)")
+      assert(exp.getMessage.contains("SyntaxError"))
+    }
+  }
+
+  test("Throwing a ZeroDivisionError") {
+    local {
+      val exp = intercept[PythonException](py"1/0")
+      assert(exp.getMessage.contains("ZeroDivisionError"))
+    }
+  }
+
+  test("Throwing a AttributeError") {
+    local {
+      val exp = intercept[PythonException](py"[1].fake_attr")
+      assert(exp.getMessage.contains("AttributeError"))
+    }
+  }
+}
+

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
@@ -51,12 +51,4 @@ class MethodCallingTest extends FunSuite with BeforeAndAfterAll {
       }
     }
   }
-
-  test("Gets exception when running Python fails") {
-    local {
-      assertThrows[PythonException] {
-        py"123[0]"
-      }
-    }
-  }
 }


### PR DESCRIPTION
While experimenting in https://github.com/shadaj/scalapy/pull/35 I realized there were no tests that raise `PythonException`.
This PR adds the `ErrorTest` suite so we have some confidence that changing the `PyErr_Occurred` comparison won't break error handling.

It's worth noting that there are many more exceptions in Python that we are not explicitly testing here.