### PR TITLE
Test reading sequence-like objects without using NumPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   - pyenv global 3.7.1
 script:
   - export LD_LIBRARY_PATH=$(python3-config --prefix)/lib
-  - pip install numpy
   - sbt test
 after_success:
   - 'if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./publish.sh; fi'

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/Reader.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/Reader.scala
@@ -47,6 +47,17 @@ object Reader extends TupleReaders {
     def read(r: PyValue): String = r.getString
   }
 
+  implicit val charReader = new Reader[Char] {
+    def read(r: PyValue): Char = {
+      val rStr = r.getString
+      if (rStr.length != 1) {
+        throw new IllegalArgumentException("Cannot extract a char from a string with length != 1")
+      } else {
+        rStr.head
+      }
+    }
+  }
+
   implicit def seqReader[T](implicit reader: Reader[T]): Reader[Seq[T]] = new Reader[Seq[T]] {
     def read(r: PyValue) = r.getSeq.map(reader.read)
   }

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
@@ -85,11 +85,10 @@ class ReaderTest extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  test("Reading from a list-like object works") {
+  test("Reading from a sequence-like object works") {
     local {
-      val np = module("numpy")
-      val arr = np.array(Seq(1, 2, 3))
-      assert(arr.as[Seq[Int]] == Seq(1, 2, 3))
+      val arr = py"'abc'"
+      assert(arr.as[Seq[Char]] == Seq('a', 'b', 'c'))
     }
   }
 


### PR DESCRIPTION
Made sure this test still checks the right behavior by reverting #29 and verifying that the new test fails.

Fixes #41 