### PR TITLE
Remove ScalaTest deprecations

### DIFF
--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ErrorTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ErrorTest.scala
@@ -1,9 +1,9 @@
 package me.shadaj.scalapy.py
 
-import org.scalatest.{FunSuite, BeforeAndAfterAll}
+import org.scalatest.funsuite.AnyFunSuite
 
 
-class ErrorTest extends FunSuite with BeforeAndAfterAll {
+class ErrorTest extends AnyFunSuite {
   test("Gets exception when running Python fails") {
     local {
       assertThrows[PythonException] {

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.funsuite.AnyFunSuite
 class MethodCallingTest extends AnyFunSuite {
   test("Can access global values") {
     local {
-      assert(global.selectDynamic("True").as[Boolean] == true)
+      assert(global.selectDynamic("True").as[Boolean])
     }
   }
 

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/MethodCallingTest.scala
@@ -1,13 +1,13 @@
 package me.shadaj.scalapy.py
 
-import org.scalatest.{FunSuite, BeforeAndAfterAll}
 import Reader._
+import org.scalatest.funsuite.AnyFunSuite
 
 @native trait StringObjectFacade extends Object {
   def replace(old: String, newValue: String): String = native
 }
 
-class MethodCallingTest extends FunSuite with BeforeAndAfterAll {
+class MethodCallingTest extends AnyFunSuite {
   test("Can access global values") {
     local {
       assert(global.selectDynamic("True").as[Boolean] == true)

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ModuleTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ModuleTest.scala
@@ -1,12 +1,12 @@
 package me.shadaj.scalapy.py
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 @native trait StringModuleFacade extends Object {
   def digits: String = native
 }
 
-class ModuleTest extends FunSuite {
+class ModuleTest extends AnyFunSuite {
   test("Can read value from module") {
     local {
       assert(module("string").digits.as[String] == "0123456789")

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
@@ -1,8 +1,8 @@
 package me.shadaj.scalapy.py
 
-import org.scalatest.{FunSuite, BeforeAndAfterAll}
+import org.scalatest.funsuite.AnyFunSuite
 
-class ReaderTest extends FunSuite with BeforeAndAfterAll {
+class ReaderTest extends AnyFunSuite {
   test("Reading a boolean") {
     local {
       assert(py"False".as[Boolean] == false)

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
@@ -5,8 +5,8 @@ import org.scalatest.funsuite.AnyFunSuite
 class ReaderTest extends AnyFunSuite {
   test("Reading a boolean") {
     local {
-      assert(py"False".as[Boolean] == false)
-      assert(py"True".as[Boolean] == true)
+      assert(!py"False".as[Boolean])
+      assert(py"True".as[Boolean])
     }
   }
 

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/WriterTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/WriterTest.scala
@@ -1,12 +1,8 @@
 package me.shadaj.scalapy.py
 
-import java.util
+import org.scalatest.funsuite.AnyFunSuite
 
-import org.scalatest.{FunSuite, BeforeAndAfterAll}
-
-import scala.collection.JavaConverters._
-
-class WriterTest extends FunSuite with BeforeAndAfterAll {
+class WriterTest extends AnyFunSuite {
   test("Writing a none value") {
     local {
       assert(Any.from(None).toString == "None")


### PR DESCRIPTION
Small PR to:
* Remove deprecation warnings
* Remove reference to `BeforeAndAfterAll` in suites where it wasn't being used

I don't know whether it is worth having a `BaseTest` trait here. Let me know.