### PR TITLE
Add cross-building to Scala 2.13

### DIFF
--- a/core/shared/src/main/scala-2.11_2.12/me/shadaj/scalapy/py/Compat.scala
+++ b/core/shared/src/main/scala-2.11_2.12/me/shadaj/scalapy/py/Compat.scala
@@ -1,0 +1,20 @@
+package me.shadaj.scalapy.py
+
+object Compat {
+
+  /**
+   * This trait extends the Scala 2.12 mutable.Map to implement the Scala 2.13 mutable.Map API.
+   * This bridges the following source incompatibility:
+   *
+   * - In Scala 2.11 and 2.12, `+=` and `-=` are abstract (must be implemented).
+   * - In Scala 2.13, `+=` and `-=` are final (cannot be overridden). They are aliases for the
+   *   abstract `addOne` and `subtractOne`.
+   */
+  trait MutableMap[K, V] extends scala.collection.mutable.Map[K, V] {
+    def addOne(kv: (K, V)): this.type
+    def subtractOne(k: K): this.type
+
+    @inline final def +=(kv: (K, V)): this.type = addOne(kv)
+    @inline final def -=(k: K): this.type = subtractOne(k)
+  }
+}

--- a/core/shared/src/main/scala-2.13/me/shadaj/scalapy/py/Compat.scala
+++ b/core/shared/src/main/scala-2.13/me/shadaj/scalapy/py/Compat.scala
@@ -1,0 +1,5 @@
+package me.shadaj.scalapy.py
+
+object Compat {
+  type MutableMap[K, V] = scala.collection.mutable.Map[K, V]
+}

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
@@ -382,7 +382,7 @@ final class PyValue private[PyValue](val underlying: Platform.Pointer, safeGloba
   }
 
   import scala.collection.mutable
-  def getMap: mutable.Map[PyValue, PyValue] = new mutable.Map[PyValue, PyValue] {
+  def getMap: mutable.Map[PyValue, PyValue] = new Compat.MutableMap[PyValue, PyValue] {
     def get(key: PyValue): Option[PyValue] = {
       val contains = CPythonAPI.PyDict_Contains(
         underlying,
@@ -406,8 +406,8 @@ final class PyValue private[PyValue](val underlying: Platform.Pointer, safeGloba
       }
     }
 
-    def +=(kv: (PyValue, PyValue)): this.type = ???
-    def -=(k: PyValue): this.type = ???
+    override def addOne(kv: (PyValue, PyValue)): this.type = ???
+    override def subtractOne(k: PyValue): this.type = ???
   }
 
   private var cleaned = false

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/Writer.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/Writer.scala
@@ -51,7 +51,7 @@ object Writer extends TupleWriters {
 
   implicit def seqWriter[T, C](implicit ev1: C => Seq[T], tWriter: Writer[T]): Writer[C] = new Writer[C] {
     override def write(v: C): PyValue = {
-      CPythonInterpreter.createList(v.view.map(tWriter.write))
+      CPythonInterpreter.createList(v.map(tWriter.write))
     }
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.3.1" )
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.0.3" )

--- a/publish.sh
+++ b/publish.sh
@@ -6,4 +6,4 @@ openssl aes-256-cbc -K $encrypted_876a1fdcb9d7_key -iv $encrypted_876a1fdcb9d7_i
 
 tar xvf secrets.tar
 
-sbt publishSignedAll sonatypeRelease
+sbt +publishSignedAll sonatypeRelease


### PR DESCRIPTION
This PR adds support for cross-building to 2.13.

By default, `coreJVM/compile` now compiles with 2.13. Running `+ coreJVM/compile` runs a full cross-version compilation run.

Scala 2.12 and 2.13 are actually source incompatible in some cases. One such example is `+=` and `-=` on `mutable.Map`: they're abstract in 2.12, but final in Scala 2.13. Because of this source incompatibility, I added a small [Scala-version-specific](https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Scala-version+specific+source+directory) compatibility layer for `mutable.Map`. The trick of `scala-2.11_2.12` was inspired by what [scala-collection-compat does](https://github.com/scala/scala-collection-compat/blob/b32553acdf256a93d5e11840336ca162f37f982b/build.sbt#L73-L77).