### PR TITLE
Fix CPythonInterpreter reference counting bugs in callGlobal, set and…

### DIFF
--- a/core/jvm/src/test/scala/me/shadaj/scalapy/ReferenceCountStressTest.scala
+++ b/core/jvm/src/test/scala/me/shadaj/scalapy/ReferenceCountStressTest.scala
@@ -1,0 +1,29 @@
+package me.shadaj.scalapy
+
+import org.scalatest.funsuite.AnyFunSuite
+import me.shadaj.scalapy.py
+
+
+class ReferenceCountStressTest extends AnyFunSuite {
+  val gc = py.module("gc")
+  val sys = py.module("sys")
+  def referenceCount(obj: py.Dynamic): Int = sys.getrefcount(obj).as[Int]
+
+  test("Repeated global function calls maintain constant reference counts") {
+    py.local  {
+      val sliceBase = py.global.slice(0)
+      val baseCount = referenceCount(sliceBase)
+
+      (0 to 4).foreach { _ =>
+        System.gc()
+        System.runFinalization()
+        gc.collect()
+
+        val slice = py.global.slice(0)
+        val count = referenceCount(slice)
+
+        assert(baseCount == count)
+      }
+    }
+  }
+}

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
@@ -37,7 +37,6 @@ object CPythonInterpreter {
     counter += 1
 
     Platform.Zone { implicit zone =>
-      CPythonAPI.Py_IncRef(value.underlying)
       CPythonAPI.PyDict_SetItemString(globals, Platform.toCString(variableName), value.underlying)
       throwErrorIfOccured()
     }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
@@ -25,6 +25,7 @@ object CPythonInterpreter {
 
   def set(variable: String, value: PyValue): Unit = {
     Platform.Zone { implicit zone =>
+      CPythonAPI.Py_IncRef(value.underlying)
       CPythonAPI.PyDict_SetItemString(globals, Platform.toCString(variable), value.underlying)
       throwErrorIfOccured()
     }
@@ -36,6 +37,7 @@ object CPythonInterpreter {
     counter += 1
 
     Platform.Zone { implicit zone =>
+      CPythonAPI.Py_IncRef(value.underlying)
       CPythonAPI.PyDict_SetItemString(globals, Platform.toCString(variableName), value.underlying)
       throwErrorIfOccured()
     }
@@ -218,6 +220,7 @@ object CPythonInterpreter {
         callable = CPythonAPI.PyDict_GetItemWithError(builtins, methodString)
       }
 
+      CPythonAPI.Py_IncRef(callable)
       CPythonAPI.Py_DecRef(methodString)
 
       throwErrorIfOccured()

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/VariableReference.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/VariableReference.scala
@@ -1,5 +1,7 @@
 package me.shadaj.scalapy.py
 
+import me.shadaj.scalapy.py.CPythonInterpreter.{globals, throwErrorIfOccured}
+
 class VariableReference(val variable: String) {
   // For tracing down variable reference creation
   // try {
@@ -21,7 +23,8 @@ class VariableReference(val variable: String) {
   def cleanup(): Unit = {
     if (!cleaned) {
       cleaned = true
-      CPythonInterpreter.eval(s"del $variable")
+      CPythonAPI.PyDict_DelItemString(globals, variable)
+      throwErrorIfOccured()
     }
   }
 
@@ -35,4 +38,4 @@ object VariableReference {
   private[py] var allocatedReferences: List[List[VariableReference]] = List.empty
 }
 
-class PythonException(s: String) extends Exception(s) 
+class PythonException(s: String) extends Exception(s)


### PR DESCRIPTION
This request just contains the fixes for the three reference counting bugs discussed in #48.

I don't have test cases that cover these particular fixes. For one, I could not isolate the first issue to a simple test case. And two, I want to take a little time to come up with a sound testing strategy for reference counting bugs which can be notoriously hard to pin down.