### PR TITLE
Handle multithreaded access to the interpreter by locking the GIL

### DIFF
--- a/core/jvm/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
@@ -7,68 +7,71 @@ class CPythonAPIInterface {
 
   @scala.native def Py_Initialize(): Unit
 
-  @scala.native def PyRun_String(str: String, start: Int, globals: Platform.Pointer, locals: Platform.Pointer): Platform.Pointer 
+  @scala.native def PyGILState_Ensure(): Int
+  @scala.native def PyGILState_Release(state: Int): Unit
 
-  @scala.native def PyUnicode_FromString(cStr: String): Platform.Pointer 
-  @scala.native def PyUnicode_AsUTF8(pyString: Platform.Pointer): Platform.Pointer 
+  @scala.native def PyRun_String(str: String, start: Int, globals: Platform.Pointer, locals: Platform.Pointer): Platform.Pointer
 
-  @scala.native def PyBool_FromLong(long: NativeLong): Platform.Pointer 
+  @scala.native def PyUnicode_FromString(cStr: String): Platform.Pointer
+  @scala.native def PyUnicode_AsUTF8(pyString: Platform.Pointer): Platform.Pointer
 
-  @scala.native def PyNumber_Negative(o1: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyNumber_Positive(o1: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyNumber_Add(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyNumber_Subtract(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyNumber_Multiply(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyNumber_TrueDivide(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyNumber_Remainder(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer 
-  
-  @scala.native def PyLong_FromLongLong(long: Long): Platform.Pointer 
-  @scala.native def PyLong_AsLong(pyLong: Platform.Pointer): Int 
-  @scala.native def PyLong_AsLongLong(pyLong: Platform.Pointer): Long 
+  @scala.native def PyBool_FromLong(long: NativeLong): Platform.Pointer
 
-  @scala.native def PyFloat_FromDouble(double: Double): Platform.Pointer 
-  @scala.native def PyFloat_AsDouble(float: Platform.Pointer): Double 
+  @scala.native def PyNumber_Negative(o1: Platform.Pointer): Platform.Pointer
+  @scala.native def PyNumber_Positive(o1: Platform.Pointer): Platform.Pointer
+  @scala.native def PyNumber_Add(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer
+  @scala.native def PyNumber_Subtract(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer
+  @scala.native def PyNumber_Multiply(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer
+  @scala.native def PyNumber_TrueDivide(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer
+  @scala.native def PyNumber_Remainder(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer
 
-  @scala.native def PyDict_New(): Platform.Pointer 
-  @scala.native def PyDict_SetItem(dict: Platform.Pointer, key: Platform.Pointer, value: Platform.Pointer): Int 
-  @scala.native def PyDict_SetItemString(dict: Platform.Pointer, key: String, value: Platform.Pointer): Int 
-  @scala.native def PyDict_Contains(dict: Platform.Pointer, key: Platform.Pointer): Int 
-  @scala.native def PyDict_GetItem(dict: Platform.Pointer, key: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyDict_GetItemString(dict: Platform.Pointer, key: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyDict_GetItemWithError(dict: Platform.Pointer, key: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyDict_DelItemString(dict: Platform.Pointer, key: String): Int 
-  @scala.native def PyDict_Keys(dict: Platform.Pointer): Platform.Pointer 
+  @scala.native def PyLong_FromLongLong(long: Long): Platform.Pointer
+  @scala.native def PyLong_AsLong(pyLong: Platform.Pointer): Int
+  @scala.native def PyLong_AsLongLong(pyLong: Platform.Pointer): Long
 
-  @scala.native def PyList_New(size: Int): Platform.Pointer 
-  @scala.native def PyList_Size(list: Platform.Pointer): NativeLong 
-  @scala.native def PyList_GetItem(list: Platform.Pointer, index: NativeLong): Platform.Pointer 
-  @scala.native def PyList_SetItem(list: Platform.Pointer, index: NativeLong, item: Platform.Pointer): Int 
+  @scala.native def PyFloat_FromDouble(double: Double): Platform.Pointer
+  @scala.native def PyFloat_AsDouble(float: Platform.Pointer): Double
 
-  @scala.native def PyTuple_New(size: Int): Platform.Pointer 
-  @scala.native def PyTuple_Size(tuple: Platform.Pointer): NativeLong 
-  @scala.native def PyTuple_GetItem(tuple: Platform.Pointer, index: NativeLong): Platform.Pointer 
-  @scala.native def PyTuple_SetItem(tuple: Platform.Pointer, index: NativeLong, item: Platform.Pointer): Int 
+  @scala.native def PyDict_New(): Platform.Pointer
+  @scala.native def PyDict_SetItem(dict: Platform.Pointer, key: Platform.Pointer, value: Platform.Pointer): Int
+  @scala.native def PyDict_SetItemString(dict: Platform.Pointer, key: String, value: Platform.Pointer): Int
+  @scala.native def PyDict_Contains(dict: Platform.Pointer, key: Platform.Pointer): Int
+  @scala.native def PyDict_GetItem(dict: Platform.Pointer, key: Platform.Pointer): Platform.Pointer
+  @scala.native def PyDict_GetItemString(dict: Platform.Pointer, key: Platform.Pointer): Platform.Pointer
+  @scala.native def PyDict_GetItemWithError(dict: Platform.Pointer, key: Platform.Pointer): Platform.Pointer
+  @scala.native def PyDict_DelItemString(dict: Platform.Pointer, key: String): Int
+  @scala.native def PyDict_Keys(dict: Platform.Pointer): Platform.Pointer
 
-  @scala.native def PyObject_Str(obj: Platform.Pointer): Platform.Pointer 
+  @scala.native def PyList_New(size: Int): Platform.Pointer
+  @scala.native def PyList_Size(list: Platform.Pointer): NativeLong
+  @scala.native def PyList_GetItem(list: Platform.Pointer, index: NativeLong): Platform.Pointer
+  @scala.native def PyList_SetItem(list: Platform.Pointer, index: NativeLong, item: Platform.Pointer): Int
+
+  @scala.native def PyTuple_New(size: Int): Platform.Pointer
+  @scala.native def PyTuple_Size(tuple: Platform.Pointer): NativeLong
+  @scala.native def PyTuple_GetItem(tuple: Platform.Pointer, index: NativeLong): Platform.Pointer
+  @scala.native def PyTuple_SetItem(tuple: Platform.Pointer, index: NativeLong, item: Platform.Pointer): Int
+
+  @scala.native def PyObject_Str(obj: Platform.Pointer): Platform.Pointer
   @scala.native def PyObject_GetItem(obj: Platform.Pointer, idx: Platform.Pointer): Platform.Pointer
-  @scala.native def PyObject_GetAttr(obj: Platform.Pointer, name: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyObject_GetAttrString(obj: Platform.Pointer, name: String): Platform.Pointer 
-  @scala.native def PyObject_SetAttr(obj: Platform.Pointer, name: Platform.Pointer, newValue: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyObject_SetAttrString(obj: Platform.Pointer, name: String, newValue: Platform.Pointer): Platform.Pointer 
-  @scala.native def PyObject_Call(obj: Platform.Pointer, args: Platform.Pointer, kwArgs: Platform.Pointer): Platform.Pointer 
+  @scala.native def PyObject_GetAttr(obj: Platform.Pointer, name: Platform.Pointer): Platform.Pointer
+  @scala.native def PyObject_GetAttrString(obj: Platform.Pointer, name: String): Platform.Pointer
+  @scala.native def PyObject_SetAttr(obj: Platform.Pointer, name: Platform.Pointer, newValue: Platform.Pointer): Platform.Pointer
+  @scala.native def PyObject_SetAttrString(obj: Platform.Pointer, name: String, newValue: Platform.Pointer): Platform.Pointer
+  @scala.native def PyObject_Call(obj: Platform.Pointer, args: Platform.Pointer, kwArgs: Platform.Pointer): Platform.Pointer
   @scala.native def PyObject_Length(obj: Platform.Pointer): NativeLong
 
-  @scala.native def PyErr_Occurred(): Platform.Pointer 
-  @scala.native def PyErr_Fetch(pType: Platform.PointerToPointer, pValue: Platform.PointerToPointer, pTraceback: Platform.PointerToPointer): Unit 
-  @scala.native def PyErr_Print(): Unit 
-  @scala.native def PyErr_Clear(): Unit 
+  @scala.native def PyErr_Occurred(): Platform.Pointer
+  @scala.native def PyErr_Fetch(pType: Platform.PointerToPointer, pValue: Platform.PointerToPointer, pTraceback: Platform.PointerToPointer): Unit
+  @scala.native def PyErr_Print(): Unit
+  @scala.native def PyErr_Clear(): Unit
 
-  @scala.native def PyEval_GetBuiltins(): Platform.Pointer 
+  @scala.native def PyEval_GetBuiltins(): Platform.Pointer
 
-  @scala.native def Py_BuildValue(str: String): Platform.Pointer 
+  @scala.native def Py_BuildValue(str: String): Platform.Pointer
 
-  @scala.native def Py_IncRef(ptr: Platform.Pointer): Unit 
-  @scala.native def Py_DecRef(ptr: Platform.Pointer): Unit 
+  @scala.native def Py_IncRef(ptr: Platform.Pointer): Unit
+  @scala.native def Py_DecRef(ptr: Platform.Pointer): Unit
 }
 
 object CPythonAPI extends CPythonAPIInterface

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
@@ -7,6 +7,7 @@ class CPythonAPIInterface {
 
   @scala.native def Py_Initialize(): Unit
 
+  @scala.native def PyEval_SaveThread(): Platform.Pointer
   @scala.native def PyGILState_Ensure(): Int
   @scala.native def PyGILState_Release(state: Int): Unit
 

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
@@ -10,7 +10,6 @@ class CPythonAPIInterface {
   @scala.native def PyEval_SaveThread(): Platform.Pointer
   @scala.native def PyGILState_Ensure(): Int
   @scala.native def PyGILState_Release(state: Int): Unit
-  @scala.native def PyGILState_Check(): Int
 
   @scala.native def PyRun_String(str: String, start: Int, globals: Platform.Pointer, locals: Platform.Pointer): Platform.Pointer
 

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
@@ -10,6 +10,7 @@ class CPythonAPIInterface {
   @scala.native def PyEval_SaveThread(): Platform.Pointer
   @scala.native def PyGILState_Ensure(): Int
   @scala.native def PyGILState_Release(state: Int): Unit
+  @scala.native def PyGILState_Check(): Int
 
   @scala.native def PyRun_String(str: String, start: Int, globals: Platform.Pointer, locals: Platform.Pointer): Platform.Pointer
 

--- a/core/jvm/src/test/scala/me/shadaj/scalapy/py/ReferenceCountStressTest.scala
+++ b/core/jvm/src/test/scala/me/shadaj/scalapy/py/ReferenceCountStressTest.scala
@@ -11,14 +11,14 @@ class ReferenceCountStressTest extends AnyFunSuite {
     val slice = global.slice(0)
 
     // first run GC to stabilize the default reference count
-    (0 to 1000).foreach { _ =>
+    (0 to 500).foreach { i =>
       System.gc()
       System.runFinalization()
       gc.collect()
     }
 
     val baseCount = referenceCount(slice)
-    (0 to 1000).foreach { _ =>
+    (0 to 500).foreach { i =>
       val myNewSlice = global.slice(0)
 
       System.gc()

--- a/core/jvm/src/test/scala/me/shadaj/scalapy/py/ReferenceCountStressTest.scala
+++ b/core/jvm/src/test/scala/me/shadaj/scalapy/py/ReferenceCountStressTest.scala
@@ -9,8 +9,18 @@ class ReferenceCountStressTest extends AnyFunSuite {
 
   test("Repeated global function calls maintain constant reference counts") {
     val slice = global.slice(0)
+
+    // first run GC to stabilize the default reference count
+    (0 to 1000).foreach { _ =>
+      System.gc()
+      System.runFinalization()
+      gc.collect()
+    }
+
     val baseCount = referenceCount(slice)
-    (0 to 10000).foreach { _ =>
+    (0 to 1000).foreach { _ =>
+      val myNewSlice = global.slice(0)
+
       System.gc()
       System.runFinalization()
       gc.collect()

--- a/core/jvm/src/test/scala/me/shadaj/scalapy/py/ThreadStressTest.scala
+++ b/core/jvm/src/test/scala/me/shadaj/scalapy/py/ThreadStressTest.scala
@@ -1,0 +1,23 @@
+package me.shadaj.scalapy.py
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ThreadStressTest extends AnyFunSuite {
+  test("Accessing the same list from many different threads works") {
+    val list = global.list()
+
+    val threads = (1 to 5000).map { i =>
+      val t = new Thread(() => {
+        list.append(i)
+      })
+
+      t.start()
+
+      t
+    }
+
+    threads.foreach(_.join())
+
+    assert(list.as[Seq[Int]].sorted == (1 to 5000).toSeq)
+  }
+}

--- a/core/native/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
@@ -6,6 +6,7 @@ import scala.scalanative.native._
 object CPythonAPI {
   def Py_Initialize(): Unit = extern
 
+  def PyEval_SaveThread(): Platform.Pointer = extern
   def PyGILState_Ensure(): Int = extern
   def PyGILState_Release(state: Int): Unit = extern
 

--- a/core/native/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/py/CPythonAPI.scala
@@ -6,6 +6,9 @@ import scala.scalanative.native._
 object CPythonAPI {
   def Py_Initialize(): Unit = extern
 
+  def PyGILState_Ensure(): Int = extern
+  def PyGILState_Release(state: Int): Unit = extern
+
   def PyRun_String(str: CString, start: Int, globals: Platform.Pointer, locals: Platform.Pointer): Platform.Pointer = extern
 
   def PyUnicode_FromString(cStr: CString): Platform.Pointer = extern

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
@@ -22,11 +22,11 @@ object CPythonInterpreter {
   @inline private[py] def withGil[T](fn: => T): T = {
     val handle = CPythonAPI.PyGILState_Ensure()
 
-    val ret = fn
-
-    CPythonAPI.PyGILState_Release(handle)
-
-    ret
+    try {
+      fn
+    } finally {
+      CPythonAPI.PyGILState_Release(handle)
+    }
   }
 
   def eval(code: String): Unit = {

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/CPythonInterpreter.scala
@@ -35,8 +35,11 @@ object CPythonInterpreter {
 
   private var counter = 0
   def getVariableReference(value: PyValue): VariableReference = {
-    val variableName = "spy_o_" + counter
-    counter += 1
+    val variableName = synchronized {
+      val ret = "spy_o_" + counter
+      counter += 1
+      ret
+    }
 
     Platform.Zone { implicit zone =>
       CPythonAPI.PyDict_SetItemString(globals, Platform.toCString(variableName), value.underlying)

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/Dynamic.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/Dynamic.scala
@@ -6,14 +6,12 @@ import scala.language.dynamics
 
 trait AnyDynamics extends scala.Any with Any with scala.Dynamic {
   def applyDynamic(method: String)(params: Any*): Dynamic = {
-    // Trick to distinguish positional Python arguments in Scala follows
-    val tupled = params.map(value => ("", value))
-    applyDynamicNamed(method)(tupled: _*)
+    Any.populateWith(CPythonInterpreter.call(value, method, params.map(_.value))).as[Dynamic]
   }
 
   def applyDynamicNamed(method: String)(params: (String, Any)*): Dynamic = {
     eval(s"${this.expr}.$method(${params.map{ case (name, value) =>
-      if(name.isEmpty) Arg(value) else Arg(name, value)  // Positional arguments have no name
+      if (name.isEmpty) Arg(value) else Arg(name, value)  // Positional arguments have no name
     }.mkString(",")})")
   }
 

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/Global.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/Global.scala
@@ -9,7 +9,7 @@ object global extends scala.Dynamic {
 
   def applyDynamicNamed(method: String)(params: (String, Any)*): Dynamic = {
     eval(s"$method(${params.map{ case (name, value) =>
-      if(name.isEmpty) Arg(value) else Arg(name, value)  // Positional arguments have no name
+      if (name.isEmpty) Arg(value) else Arg(name, value)  // Positional arguments have no name
     }.mkString(",")})")
   }
 

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/VariableReference.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/VariableReference.scala
@@ -24,8 +24,10 @@ class VariableReference(val variable: String) {
     if (!cleaned) {
       cleaned = true
       Platform.Zone { implicit zone =>
-        CPythonAPI.PyDict_DelItemString(globals, Platform.toCString(variable))
-        throwErrorIfOccured()
+        CPythonInterpreter.withGil {
+          CPythonAPI.PyDict_DelItemString(globals, Platform.toCString(variable))
+          throwErrorIfOccured()
+        }
       }
     }
   }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/VariableReference.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/VariableReference.scala
@@ -20,21 +20,17 @@ class VariableReference(val variable: String) {
 
   private var cleaned = false
 
-  def cleanup(): Unit = {
+  def cleanup(): Unit = CPythonInterpreter.withGil {
     if (!cleaned) {
       cleaned = true
       Platform.Zone { implicit zone =>
-        CPythonInterpreter.withGil {
-          CPythonAPI.PyDict_DelItemString(globals, Platform.toCString(variable))
-          throwErrorIfOccured()
-        }
+        CPythonAPI.PyDict_DelItemString(globals, Platform.toCString(variable))
+        throwErrorIfOccured()
       }
     }
   }
 
-  override def finalize(): Unit = {
-    cleanup()
-  }
+  override def finalize(): Unit = cleanup()
 }
 
 object VariableReference {


### PR DESCRIPTION
A more complete fix to #49, but still not done yet. In another PR, will be adding GIL support which is needed for proper threading support.