### PR TITLE
Add python3.7m in library list

### DIFF
--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -8,7 +8,7 @@ import com.sun.jna.{Native, NativeLong, Memory}
 class CPythonAPIInterface {
   val pythonLibrariesToTry =
     sys.env.get("SCALAPY_PYTHON_LIBRARY").toSeq ++
-      Seq("python3", "python3.7")
+      Seq("python3", "python3.7", "python3.7m")
 
   pythonLibrariesToTry.find(n => Try(Native.register(n)).isSuccess)
 


### PR DESCRIPTION
All my conda-based python 3.7 installations have a `libpython3.7m.so` / `libpython3.7m.dylib` / `python3.7m.dll` (with a `m` right after `3.7`), and no `python3` or `python3.7` libraries. I would expect this library name to be rather widespread, so I guess it makes sense to add it here.