### PR TITLE
Complete the example used in the documentation for specific python version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,3 +50,11 @@ To convert Python values back into Scala, we use the `.as` method and pass in th
 ```scala mdoc
 val listLength = listLengthPython.as[Int]
 ```
+## Execution
+ScalaPy uses by default python3, python3.7, python3.7m. If you use an other version of python, you should define the variable `SCALAPY_PYTHON_LIBRARY`
+```shell
+python --version
+# Python 3.8.6
+export SCALAPY_PYTHON_LIBRARY=python3.8
+sbt run
+```


### PR DESCRIPTION
I have a problem when I try to execute the example in getting start page, because I use python 3.8. I have spent much time to search the solution to make run the example. I complete the documentation for the new users