### PR TITLE
Allow converting nested sequences to Python using a single call to `toPythonCopy` or `toPythonProxy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## vNEXT
 ### Highlights :tada:
++ Allow converting nested sequences to Python using a single call to `toPythonCopy` or `toPythonProxy` [PR #178](https://github.com/shadaj/scalapy/pull/178)
 + Add API equivalents for the Python `del` keyword (`del foo.bar`, `del foo["key"]`, and `del foo`) ([PR #175](https://github.com/shadaj/scalapy/pull/175), [PR #177](https://github.com/shadaj/scalapy/pull/177))
 
 ### Breaking Changes :warning:

--- a/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
@@ -240,7 +240,7 @@ object CPythonInterpreter {
     }).ptr
   }
 
-  def createListCopy[T](seq: Seq[T], elemConv: T => PyValue): PyValue = {
+  def createListCopy[T](seq: scala.collection.Seq[T], elemConv: T => PyValue): PyValue = {
     withGil {
       val retPtr = CPythonAPI.PyList_New(seq.size)
       seq.zipWithIndex.foreach { case (v, i) =>
@@ -254,7 +254,7 @@ object CPythonInterpreter {
   }
 
   val seqProxyClass = selectGlobal("SequenceProxy", safeGlobal = true)
-  def createListProxy[T](seq: Seq[T], elemConv: T => PyValue): PyValue = {
+  def createListProxy[T](seq: scala.collection.Seq[T], elemConv: T => PyValue): PyValue = {
     call(seqProxyClass, Seq(
       createLambda(_ => valueFromLong(seq.size)),
       createLambda(args => {

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/WriterTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/WriterTest.scala
@@ -88,9 +88,25 @@ class WriterTest extends AnyFunSuite {
       assert(Dynamic.global.list(
         Dynamic.global.map(
           Dynamic.global.list,
-          Seq[Array[Int]](Array(1), Array(2)).map(_.toPythonCopy).toPythonCopy
+          Seq[Array[Int]](Array(1), Array(2)).toPythonCopy
         )
       ).toString == "[[1], [2]]")
+    }
+  }
+
+  test("Writing a sequence of arrays as a proxy") {
+    local {
+      val seq = Seq[Array[Int]](Array(1), Array(2))
+      val proxy = seq.toPythonProxy
+      assert(Dynamic.global.list(
+        Dynamic.global.map(Dynamic.global.list, proxy)
+      ).toString == "[[1], [2]]")
+
+      seq(0)(0) = 100
+
+      assert(Dynamic.global.list(
+        Dynamic.global.map(Dynamic.global.list, proxy)
+      ).toString == "[[100], [2]]")
     }
   }
 
@@ -99,7 +115,7 @@ class WriterTest extends AnyFunSuite {
       assert(Dynamic.global.list(
         Dynamic.global.map(
           Dynamic.global.list,
-          Seq[Seq[Int]](Seq(1), Seq(2)).map(_.toPythonCopy).toPythonCopy
+          Seq[Seq[Int]](Seq(1), Seq(2)).toPythonCopy
         )
       ).toString == "[[1], [2]]")
     }


### PR DESCRIPTION
Fixes #162