### PR TITLE
Optimize sequence conversions by avoiding intermediate PyValue allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 ## vNEXT
 ### Highlights :tada:
++ Significantly optimize transfers from Scala to Python, which are now up to 5x faster on the JVM and 4x faster on Scala Native ([PR #179](https://github.com/shadaj/scalapy/pull/179))
++ Python values can now be loaded into any immutable Scala collection type as a copy, not just `Seq` ([PR #179](https://github.com/shadaj/scalapy/pull/179))
 + Allow converting nested sequences to Python using a single call to `toPythonCopy` or `toPythonProxy` ([PR #178](https://github.com/shadaj/scalapy/pull/178))
 + Add API equivalents for the Python `del` keyword (`del foo.bar`, `del foo["key"]`, and `del foo`) ([PR #175](https://github.com/shadaj/scalapy/pull/175), [PR #177](https://github.com/shadaj/scalapy/pull/177))
 
 ### Breaking Changes :warning:
++ Reading a Python collection as an immutable sequence will now load a copy. To load a proxy that can observe changes, load sequences with `.as[mutable.Seq[...]]``` ([PR #179](https://github.com/shadaj/scalapy/pull/179))
 + Calling the `apply` method on a `py.Dynamic` value will now directly call the original value as-is instead of the `apply` method of the value in Python ([PR #177](https://github.com/shadaj/scalapy/pull/177))
   + To call the original value with keyword arguments, you can use the new `applyNamed` API, passing in tuples of keyword arguments and values
   + To call the original `apply` method in Python, use `applyDynamic` explicitly (`myValue.applyDynamic("apply")(arg1, arg2, ...)`)

--- a/bench/scripts/run.py
+++ b/bench/scripts/run.py
@@ -50,12 +50,12 @@ sizes = [2 ** x for x in range(1, 15)]
 
 benchmarks = [
     ('CreatePythonCopyBenchmark', sizes, None),
-    # ('CreatePythonProxyBenchmark', sizes, None),
-    # ('SumPythonCopyBenchmark', sizes, None),
-    # ('SumPythonProxyBenchmark', sizes, None),
-    # ('SumScalaBenchmark', sizes, None),
-    # ('TensorFlowAppScalaPyBenchmark', [0], 50),
-    # ('TensorFlowAppPythonBenchmark', [0], 50),
+    ('CreatePythonProxyBenchmark', sizes, None),
+    ('SumPythonCopyBenchmark', sizes, None),
+    ('SumPythonProxyBenchmark', sizes, None),
+    ('SumScalaBenchmark', sizes, None),
+    ('TensorFlowAppScalaPyBenchmark', [0], 50),
+    ('TensorFlowAppPythonBenchmark', [0], 50),
 ]
 
 configurations = [

--- a/bench/scripts/run.py
+++ b/bench/scripts/run.py
@@ -46,16 +46,16 @@ def compile(bench, compilecmd):
 
 sbt = where('sbt')
 
-sizes = [1, 5, 10, 50, 100]
+sizes = [2 ** x for x in range(1, 15)]
 
 benchmarks = [
     ('CreatePythonCopyBenchmark', sizes, None),
-    ('CreatePythonProxyBenchmark', sizes, None),
-    ('SumPythonCopyBenchmark', sizes, None),
-    ('SumPythonProxyBenchmark', sizes, None),
-    ('SumScalaBenchmark', sizes, None),
-    ('TensorFlowAppScalaPyBenchmark', [0], 50),
-    ('TensorFlowAppPythonBenchmark', [0], 50),
+    # ('CreatePythonProxyBenchmark', sizes, None),
+    # ('SumPythonCopyBenchmark', sizes, None),
+    # ('SumPythonProxyBenchmark', sizes, None),
+    # ('SumScalaBenchmark', sizes, None),
+    # ('TensorFlowAppScalaPyBenchmark', [0], 50),
+    # ('TensorFlowAppPythonBenchmark', [0], 50),
 ]
 
 configurations = [

--- a/bench/scripts/summary.py
+++ b/bench/scripts/summary.py
@@ -31,24 +31,25 @@ def config_data(bench, conf):
 
 def peak_performance():
     out = []
-    for bench in bench_and_size:
-        res = []
-        for conf in configurations:
-            try:
-                processed = config_data(bench, conf)
-                print("{} - {}: mean {} ns, stddev {} ns".format(bench, conf, np.percentile(processed, 50), np.std(processed)))
-                res.append(np.percentile(processed, 50))
-            except IndexError:
-                res.append(0)
-        out.append(res)
+    for bench, sizes, _ in benchmarks:
+        for size in sizes:
+            res = []
+            for conf in configurations:
+                try:
+                    processed = config_data(bench + "-" + str(size), conf)
+                    print("{} ({}) - {}: mean {} ns, stddev {} ns".format(bench, size, conf, np.percentile(processed, 50), np.std(processed)))
+                    res.append(np.percentile(processed, 50))
+                except IndexError:
+                    res.append(0)
+            out.append([bench, str(size)] + [str(x) for x in res])
     return out
 
 if __name__ == '__main__':
-    leading = ['name']
+    leading = ['name', "size"]
     for conf in configurations:
         leading.append(conf)
-    zipped_means = list(zip(bench_and_size, peak_performance()))
+    zipped_means = peak_performance()
     print(','.join(leading))
-    for bench, res in zipped_means:
-        print(','.join([bench] + list(map(str, res))))
+    for res in zipped_means:
+        print(','.join(res))
 

--- a/bench/src/main/scala/CreatePythonCopyBenchmark.scala
+++ b/bench/src/main/scala/CreatePythonCopyBenchmark.scala
@@ -5,14 +5,14 @@ import me.shadaj.scalapy.py.SeqConverters
 object CreatePythonCopyBenchmark extends communitybench.Benchmark {
   PyValue.disableAllocationWarning()
   
-  var values: Vector[Double] = null
+  var values: Array[Double] = null
   def run(input: String): Int = py.local {
     val pySequence = values.toPythonCopy
     py.Dynamic.global.len(pySequence).as[Int]
   }
 
   override def main(args: Array[String]): Unit = {
-    values = Vector.fill(args.last.toInt)(math.random)
+    values = Array.fill(args.last.toInt)(math.random)
     super.main(args.init)
   }
 }

--- a/bench/src/main/scala/CreatePythonProxyBenchmark.scala
+++ b/bench/src/main/scala/CreatePythonProxyBenchmark.scala
@@ -5,14 +5,14 @@ import me.shadaj.scalapy.py.SeqConverters
 object CreatePythonProxyBenchmark extends communitybench.Benchmark {
   PyValue.disableAllocationWarning()
   
-  var values: Vector[Double] = null
+  var values: Array[Double] = null
   def run(input: String): Int = py.local {
     val pySequence = values.toPythonProxy
     py.Dynamic.global.len(pySequence).as[Int]
   }
 
   override def main(args: Array[String]): Unit = {
-    values = Vector.fill(args.last.toInt)(math.random)
+    values = Array.fill(args.last.toInt)(math.random)
     super.main(args.init)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -71,14 +71,14 @@ lazy val core = crossProject(JVMPlatform, NativePlatform)
            |  }
            |}"""
       }
-    
+
       val toWrite =
         s"""package me.shadaj.scalapy.readwrite
            |import me.shadaj.scalapy.interpreter.PyValue
            |trait TupleReaders {
            |${methods.mkString("\n")}
            |}""".stripMargin
-    
+
       IO.write(fileToWrite, toWrite)
       Seq(fileToWrite)
     },
@@ -94,14 +94,14 @@ lazy val core = crossProject(JVMPlatform, NativePlatform)
            |  }
            |}"""
       }
-    
+
       val toWrite =
         s"""package me.shadaj.scalapy.readwrite
            |import me.shadaj.scalapy.interpreter.{CPythonInterpreter, PyValue}
            |trait TupleWriters {
            |${methods.mkString("\n")}
            |}""".stripMargin
-    
+
       IO.write(fileToWrite, toWrite)
       Seq(fileToWrite)
     },
@@ -120,14 +120,14 @@ lazy val core = crossProject(JVMPlatform, NativePlatform)
            |  }
            |}"""
       }
-    
+
       val toWrite =
         s"""package me.shadaj.scalapy.readwrite
            |import me.shadaj.scalapy.interpreter.{CPythonInterpreter, PyValue}
            |trait FunctionReaders {
            |${methods.mkString("\n")}
            |}""".stripMargin
-    
+
       IO.write(fileToWrite, toWrite)
       Seq(fileToWrite)
     },
@@ -143,14 +143,14 @@ lazy val core = crossProject(JVMPlatform, NativePlatform)
            |  }
            |}"""
       }
-    
+
       val toWrite =
         s"""package me.shadaj.scalapy.readwrite
            |import me.shadaj.scalapy.interpreter.{CPythonInterpreter, PyValue}
            |trait FunctionWriters {
            |${methods.mkString("\n")}
            |}""".stripMargin
-    
+
       IO.write(fileToWrite, toWrite)
       Seq(fileToWrite)
     },

--- a/build.sbt
+++ b/build.sbt
@@ -154,6 +154,7 @@ lazy val core = crossProject(JVMPlatform, NativePlatform)
       IO.write(fileToWrite, toWrite)
       Seq(fileToWrite)
     },
+    libraryDependencies += "org.scala-lang.modules" %%% "scala-collection-compat" % "2.4.3",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.8" % Test,
     unmanagedSourceDirectories in Compile += {

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -88,6 +88,7 @@ class CPythonAPIInterface {
   @scala.native def PyObject_Length(obj: Platform.Pointer): NativeLong
 
   @scala.native def PySequence_GetItem(obj: Platform.Pointer, idx: Int): Platform.Pointer
+  @scala.native def PySequence_SetItem(obj: Platform.Pointer, idx: Int, v: Platform.Pointer): Platform.Pointer
   @scala.native def PySequence_Length(obj: Platform.Pointer): NativeLong
 
   @scala.native def PyErr_Occurred(): Platform.Pointer

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -21,6 +21,9 @@ object Platform {
   type Pointer = jna.Pointer
   type PointerToPointer = jna.Pointer
   type FunctionPointer = jna.Callback
+  type ThreadLocal[T] = java.lang.ThreadLocal[T]
+
+  def threadLocalWithInitial[T](initial: () => T) = java.lang.ThreadLocal.withInitial(() => initial())
 
   def allocPointerToPointer: PointerToPointer = {
     new jna.Memory(Native.POINTER_SIZE)

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -65,6 +65,7 @@ object CPythonAPI {
   def PyObject_Length(obj: Platform.Pointer): CSize = extern
 
   def PySequence_GetItem(obj: Platform.Pointer, idx: Int): Platform.Pointer = extern
+  def PySequence_SetItem(obj: Platform.Pointer, idx: Int, v: Platform.Pointer): Platform.Pointer = extern
   def PySequence_Length(obj: Platform.Pointer): CSize = extern
 
   def PyErr_Occurred(): Platform.Pointer = extern

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -25,6 +25,9 @@ object Platform {
   type CString = sn.CString
   type Pointer = Ptr[Byte]
   type PointerToPointer = Ptr[Ptr[Byte]]
+  type ThreadLocal[T] = SingleThreadLocal[T]
+
+  def threadLocalWithInitial[T](initial: () => T) = SingleThreadLocal.withInitial(initial)
 
   def allocPointerToPointer(implicit zone: sn.Zone): PointerToPointer = {
     sn.alloc[Ptr[Byte]]

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/ThreadLocal.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/ThreadLocal.scala
@@ -1,0 +1,9 @@
+package me.shadaj.scalapy.interpreter
+
+private[scalapy] class SingleThreadLocal[T](value: T) {
+  def get(): T = value
+}
+
+object SingleThreadLocal {
+  def withInitial[T](initial: () => T) = new SingleThreadLocal[T](initial())
+}

--- a/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
@@ -232,25 +232,26 @@ object CPythonInterpreter {
   // Hack to patch around Scala Native not letting us auto-box pointers
   private class PointerBox(val ptr: Platform.Pointer)
 
-  private def toNewString(v: String) = {
+  private[scalapy] def toNewString(v: String) = {
     (Platform.Zone { implicit zone =>
-      withGil(new PointerBox(CPythonAPI.PyUnicode_FromString(
+      val res = withGil(new PointerBox(CPythonAPI.PyUnicode_FromString(
         Platform.toCString(v, java.nio.charset.Charset.forName("UTF-8"))
       )))
+      throwErrorIfOccured()
+      res
     }).ptr
   }
 
-  def createListCopy[T](seq: scala.collection.Seq[T], elemConv: T => PyValue): PyValue = {
-    withGil {
-      val retPtr = CPythonAPI.PyList_New(seq.size)
-      seq.zipWithIndex.foreach { case (v, i) =>
-        val converted = elemConv(v)
-        CPythonAPI.Py_IncRef(converted.underlying) // SetItem steals reference
-        CPythonAPI.PyList_SetItem(retPtr, Platform.intToCSize(i), converted.underlying)
-      }
-
-      PyValue.fromNew(retPtr)
+  // elemConv must produce a pointer that is owned by the converion process
+  // and has no other references
+  def createListCopy[T](seq: scala.collection.Seq[T], elemConv: T => Platform.Pointer): Platform.Pointer = withGil {
+    val retPtr = CPythonAPI.PyList_New(seq.size)
+    seq.iterator.zipWithIndex.foreach { case (v, i) =>
+      val converted = elemConv(v)
+      CPythonAPI.PyList_SetItem(retPtr, Platform.intToCSize(i), converted)
     }
+
+    retPtr
   }
 
   val seqProxyClass = selectGlobal("SequenceProxy", safeGlobal = true)
@@ -482,7 +483,7 @@ object CPythonInterpreter {
 
         throwErrorIfOccured()
 
-        PyValue.fromNew(gottenValue, safeGlobal)
+        PyValue.fromBorrowed(gottenValue, safeGlobal)
       }
     }
   }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
@@ -232,14 +232,14 @@ object CPythonInterpreter {
   // Hack to patch around Scala Native not letting us auto-box pointers
   private class PointerBox(val ptr: Platform.Pointer)
 
-  private[scalapy] def toNewString(v: String) = {
-    (Platform.Zone { implicit zone =>
-      val res = withGil(new PointerBox(CPythonAPI.PyUnicode_FromString(
+  private[scalapy] def toNewString(v: String) = withGil {
+    val res = Platform.Zone { implicit zone =>
+      new PointerBox(CPythonAPI.PyUnicode_FromString(
         Platform.toCString(v, java.nio.charset.Charset.forName("UTF-8"))
-      )))
-      throwErrorIfOccured()
-      res
-    }).ptr
+      ))
+    }
+    throwErrorIfOccured()
+    res.ptr
   }
 
   // elemConv must produce a pointer that is owned by the converion process
@@ -297,14 +297,14 @@ object CPythonInterpreter {
     ), java.nio.charset.Charset.forName("UTF-8"))
   }
 
-  def throwErrorIfOccured() = {
+  def throwErrorIfOccured() = withGil {
     if (Platform.pointerToLong(CPythonAPI.PyErr_Occurred()) != 0) {
       Platform.Zone { implicit zone =>
         val pType = Platform.allocPointerToPointer
         val pValue = Platform.allocPointerToPointer
         val pTraceback = Platform.allocPointerToPointer
 
-        withGil(CPythonAPI.PyErr_Fetch(pType, pValue, pTraceback))
+        CPythonAPI.PyErr_Fetch(pType, pValue, pTraceback)
 
         val pTypeStringified = pointerPointerToString(pType)
 
@@ -474,7 +474,7 @@ object CPythonInterpreter {
 
       withGil {
         var gottenValue = CPythonAPI.PyDict_GetItemWithError(globals, nameString)
-        if (gottenValue == null) {
+        if (Platform.pointerToLong(gottenValue) == 0) {
           CPythonAPI.PyErr_Clear()
           gottenValue = CPythonAPI.PyDict_GetItemWithError(builtins, nameString)
         }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/PyValue.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/PyValue.scala
@@ -13,7 +13,7 @@ final class PyValue private[PyValue](var underlying: Platform.Pointer, safeGloba
   }
 
   if (!safeGlobal && myAllocatedValues.nonEmpty && myAllocatedValues.head != null) {
-    myAllocatedValues.head.addOne(this)
+    myAllocatedValues.head.enqueue(this)
   }
 
   def getStringified: String = CPythonInterpreter.withGil {
@@ -155,7 +155,9 @@ final class PyValue private[PyValue](var underlying: Platform.Pointer, safeGloba
 
 object PyValue {
   import scala.collection.mutable
-  private[scalapy] val allocatedValues: Platform.ThreadLocal[Stack[Queue[PyValue]]] = Platform.threadLocalWithInitial(() => Stack.empty)
+  private[scalapy] val allocatedValues: Platform.ThreadLocal[Stack[Queue[PyValue]]] = Platform.threadLocalWithInitial(
+    () => Stack.empty[Queue[PyValue]]
+  )
   private[scalapy] var disabledAllocationWarning = false
 
   def fromNew(underlying: Platform.Pointer, safeGlobal: Boolean = false): PyValue = {

--- a/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/PyValue.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/PyValue.scala
@@ -12,7 +12,7 @@ final class PyValue private[PyValue](var underlying: Platform.Pointer, safeGloba
     println(s"Warning: the value ${this.getStringified} was allocated into a global space, which means it will not be garbage collected in Scala Native")
   }
 
-  if (!safeGlobal && myAllocatedValues.nonEmpty && myAllocatedValues.head != null) {
+  if (!safeGlobal && myAllocatedValues.nonEmpty) {
     myAllocatedValues.head.enqueue(this)
   }
 
@@ -173,14 +173,5 @@ object PyValue {
 
   def disableAllocationWarning(): Unit = {
     disabledAllocationWarning = true
-  }
-
-  private[scalapy] def withManualCleanup[T](thunk: => T): T = {
-    try {
-      PyValue.allocatedValues.get().push(null)
-      thunk
-    } finally {
-      assert(PyValue.allocatedValues.get().pop() == null)
-    }
   }
 }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/PyValue.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/PyValue.scala
@@ -2,13 +2,18 @@ package me.shadaj.scalapy.interpreter
 
 import me.shadaj.scalapy.util.Compat
 
-final class PyValue private[PyValue](val underlying: Platform.Pointer, safeGlobal: Boolean = false) {
-  if (Platform.isNative && PyValue.allocatedValues.isEmpty && !safeGlobal && !PyValue.disabledAllocationWarning) {
+import scala.collection.mutable
+import scala.collection.mutable.Stack
+import scala.collection.mutable.Queue
+
+final class PyValue private[PyValue](var underlying: Platform.Pointer, safeGlobal: Boolean = false) {
+  val myAllocatedValues = PyValue.allocatedValues.get
+  if (Platform.isNative && myAllocatedValues.isEmpty && !safeGlobal && !PyValue.disabledAllocationWarning) {
     println(s"Warning: the value ${this.getStringified} was allocated into a global space, which means it will not be garbage collected in Scala Native")
   }
 
-  if (!safeGlobal && PyValue.allocatedValues.nonEmpty) {
-    PyValue.allocatedValues = (this :: PyValue.allocatedValues.head) :: PyValue.allocatedValues.tail
+  if (!safeGlobal && myAllocatedValues.nonEmpty && myAllocatedValues.head != null) {
+    myAllocatedValues.head.addOne(this)
   }
 
   def getStringified: String = CPythonInterpreter.withGil {
@@ -67,20 +72,31 @@ final class PyValue private[PyValue](val underlying: Platform.Pointer, safeGloba
     def iterator: Iterator[PyValue] = (0 until length).toIterator.map(apply)
   }
 
-  def getSeq: Seq[PyValue] = new Seq[PyValue] {
+  def getSeq[T](read: PyValue => T, write: T => PyValue): mutable.Seq[T] = new mutable.Seq[T] {
     def length: Int = CPythonInterpreter.withGil {
       val ret = Platform.cSizeToLong(CPythonAPI.PySequence_Length(underlying)).toInt
       CPythonInterpreter.throwErrorIfOccured()
       ret
     }
 
-    def apply(idx: Int): PyValue = CPythonInterpreter.withGil {
+    def apply(idx: Int): T = CPythonInterpreter.withGil {
       val ret = CPythonAPI.PySequence_GetItem(underlying, idx)
       CPythonInterpreter.throwErrorIfOccured()
-      PyValue.fromNew(ret)
+      val wrappedValue = PyValue.fromNew(ret, safeGlobal = true)
+      val res = read(wrappedValue)
+      wrappedValue.cleanup()
+      res
     }
 
-    def iterator: Iterator[PyValue] = (0 until length).toIterator.map(apply)
+    def update(idx: Int, elem: T): Unit = CPythonInterpreter.withGil {
+      PyValue.withManualCleanup {
+        val written = write(elem)
+        CPythonAPI.PySequence_SetItem(underlying, idx, written.underlying)
+        written.cleanup()
+      }
+    }
+
+    def iterator: Iterator[T] = (0 until length).toIterator.map(apply)
   }
 
   import scala.collection.mutable
@@ -101,9 +117,9 @@ final class PyValue private[PyValue](val underlying: Platform.Pointer, safeGloba
     }
 
     def iterator: Iterator[(PyValue, PyValue)] = CPythonInterpreter.withGil {
-      val keysList = new PyValue(CPythonAPI.PyDict_Keys(underlying))
+      val keysList = PyValue.fromNew(CPythonAPI.PyDict_Keys(underlying))
       CPythonInterpreter.throwErrorIfOccured()
-      keysList.getSeq.toIterator.map { k =>
+      keysList.getSeq(_.dup(), null).toIterator.map { k =>
         (k, get(k).get)
       }
     }
@@ -112,33 +128,55 @@ final class PyValue private[PyValue](val underlying: Platform.Pointer, safeGloba
     override def subtractOne(k: PyValue): this.type = ???
   }
 
-  private[scalapy] var cleaned = false
-
   def cleanup(): Unit = CPythonInterpreter.withGil {
-    if (!cleaned) {
-      cleaned = true
+    if (underlying != null) {
       CPythonAPI.Py_DecRef(underlying)
+      underlying = null
+    } else {
+      throw new IllegalStateException("This PyValue has already been cleaned up")
     }
   }
 
-  override def finalize(): Unit = cleanup()
+  private[scalapy] def dup(): PyValue = {
+    if (underlying != null) {
+      PyValue.fromBorrowed(underlying)
+    } else {
+      throw new IllegalStateException("Cannot dup a PyValue that has been cleaned")
+    }
+  }
+
+  override def finalize(): Unit = CPythonInterpreter.withGil {
+    if (underlying != null) {
+      CPythonAPI.Py_DecRef(underlying)
+      underlying = null
+    }
+  }
 }
 
 object PyValue {
   import scala.collection.mutable
-  private[scalapy] var allocatedValues: List[List[PyValue]] = List.empty
+  private[scalapy] val allocatedValues: Platform.ThreadLocal[Stack[Queue[PyValue]]] = Platform.threadLocalWithInitial(() => Stack.empty)
   private[scalapy] var disabledAllocationWarning = false
 
   def fromNew(underlying: Platform.Pointer, safeGlobal: Boolean = false): PyValue = {
     new PyValue(underlying, safeGlobal)
   }
 
-  def fromBorrowed(underlying: Platform.Pointer): PyValue = {
+  def fromBorrowed(underlying: Platform.Pointer, safeGlobal: Boolean = false): PyValue = {
     CPythonInterpreter.withGil(CPythonAPI.Py_IncRef(underlying))
-    new PyValue(underlying)
+    new PyValue(underlying, safeGlobal)
   }
 
   def disableAllocationWarning(): Unit = {
     disabledAllocationWarning = true
+  }
+
+  private[scalapy] def withManualCleanup[T](thunk: => T): T = {
+    try {
+      PyValue.allocatedValues.get().push(null)
+      thunk
+    } finally {
+      assert(PyValue.allocatedValues.get().pop() == null)
+    }
   }
 }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/Any.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/Any.scala
@@ -22,7 +22,6 @@ trait Any { self =>
 
   final def as[T: Reader]: T = implicitly[Reader[T]].read(value)
 
-
   final def del(): Unit = {
     value.cleanup()
     cleaned = true

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/Dynamic.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/Dynamic.scala
@@ -28,31 +28,37 @@ object Dynamic {
 
 trait AnyDynamics extends Any with scala.Dynamic {
   def apply(params: Any*): Dynamic = {
-    Any.populateWith(CPythonInterpreter.call(value, params.map(_.value), Seq())).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(
+      CPythonInterpreter.call(value, params.map(_.value), Seq())
+    )
   }
 
   def applyDynamic(method: String)(params: Any*): Dynamic = {
-    Any.populateWith(CPythonInterpreter.call(value, method, params.map(_.value), Seq())).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(
+      CPythonInterpreter.call(value, method, params.map(_.value), Seq())
+    )
   }
 
   def applyNamed(params: (String, Any)*): Dynamic = {
-    Any.populateWith(CPythonInterpreter.call(
+    implicitly[FacadeCreator[Dynamic]].create(CPythonInterpreter.call(
       value,
       params.filter(_._1.isEmpty).map(_._2.value),
       params.filter(_._1.nonEmpty).map(t => (t._1, t._2.value))
-    )).as[Dynamic]
+    ))
   }
 
   def applyDynamicNamed(method: String)(params: (String, Any)*): Dynamic = {
-    Any.populateWith(CPythonInterpreter.call(
+    implicitly[FacadeCreator[Dynamic]].create(CPythonInterpreter.call(
       value, method,
       params.filter(_._1.isEmpty).map(_._2.value),
       params.filter(_._1.nonEmpty).map(t => (t._1, t._2.value))
-    )).as[Dynamic]
+    ))
   }
 
   def selectDynamic(term: String): Dynamic = {
-    Any.populateWith(CPythonInterpreter.select(value, term)).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(
+      CPythonInterpreter.select(value, term)
+    )
   }
 
   def updateDynamic(name: String)(newValue: Any): Unit = {
@@ -60,7 +66,9 @@ trait AnyDynamics extends Any with scala.Dynamic {
   }
 
   def bracketAccess(key: Any): Dynamic = {
-    Any.populateWith(CPythonInterpreter.selectBracket(value, key.value)).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(
+      CPythonInterpreter.selectBracket(value, key.value)
+    )
   }
 
   def bracketUpdate(key: Any, newValue: Any): Unit = {
@@ -76,30 +84,30 @@ trait AnyDynamics extends Any with scala.Dynamic {
   }
 
   def unary_+(): Dynamic = {
-    Any.populateWith(CPythonInterpreter.unaryPos(value)).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(CPythonInterpreter.unaryPos(value))
   }
 
   def unary_-(): Dynamic = {
-    Any.populateWith(CPythonInterpreter.unaryNeg(value)).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(CPythonInterpreter.unaryNeg(value))
   }
 
   def +(that: Any): Dynamic = {
-    Any.populateWith(CPythonInterpreter.binaryAdd(value, that.value)).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(CPythonInterpreter.binaryAdd(value, that.value))
   }
 
   def -(that: Any): Dynamic = {
-    Any.populateWith(CPythonInterpreter.binarySub(value, that.value)).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(CPythonInterpreter.binarySub(value, that.value))
   }
 
   def *(that: Any): Dynamic = {
-    Any.populateWith(CPythonInterpreter.binaryMul(value, that.value)).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(CPythonInterpreter.binaryMul(value, that.value))
   }
 
   def /(that: Any): Dynamic = {
-    Any.populateWith(CPythonInterpreter.binaryDiv(value, that.value)).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(CPythonInterpreter.binaryDiv(value, that.value))
   }
 
   def %(that: Any): Dynamic = {
-    Any.populateWith(CPythonInterpreter.binaryMod(value, that.value)).as[Dynamic]
+    implicitly[FacadeCreator[Dynamic]].create(CPythonInterpreter.binaryMod(value, that.value))
   }
 }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
@@ -7,6 +7,7 @@ import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.FacadeCreator
 
 import scala.collection.mutable
+import scala.collection.compat._
 
 trait Reader[T] {
   // the value is borrowed, the reader must never leak references to the PyValue
@@ -69,8 +70,8 @@ object Reader extends TupleReaders with FunctionReaders {
     def read(r: PyValue) = r.dup().getSeq(reader.read, writer.write)
   }
 
-  implicit def seqReader[T](implicit reader: Reader[T]): Reader[Seq[T]] = new Reader[Seq[T]] {
-    def read(r: PyValue) = r.dup().getSeq(reader.read, null).toSeq
+  implicit def seqReader[T, C[A] <: Iterable[A]](implicit reader: Reader[T], bf: Factory[T, C[T]]): Reader[C[T]] = new Reader[C[T]] {
+    def read(r: PyValue) = bf.fromSpecific(r.dup().getSeq(reader.read, null))
   }
 
   implicit def mapReader[I, O](implicit readerI: Reader[I], readerO: Reader[O]): Reader[Map[I, O]] = new Reader[Map[I, O]] {

--- a/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
@@ -67,7 +67,7 @@ object Reader extends TupleReaders with FunctionReaders {
   }
 
   implicit def mutableSeqReader[T](implicit reader: Reader[T], writer: Writer[T]): Reader[mutable.Seq[T]] = new Reader[mutable.Seq[T]] {
-    def read(r: PyValue) = r.dup().getSeq(reader.read, writer.write)
+    def read(r: PyValue) = r.dup().getSeq(reader.read, writer.writeNative)
   }
 
   implicit def seqReader[T, C[A] <: Iterable[A]](implicit reader: Reader[T], bf: Factory[T, C[T]]): Reader[C[T]] = new Reader[C[T]] {

--- a/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Writer.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Writer.scala
@@ -3,66 +3,89 @@ package me.shadaj.scalapy.readwrite
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
-import me.shadaj.scalapy.interpreter.{CPythonInterpreter, PyValue}
+import me.shadaj.scalapy.interpreter.{CPythonInterpreter, PyValue, Platform}
 import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.|
 import me.shadaj.scalapy.py.PyQuote
+import me.shadaj.scalapy.interpreter.CPythonAPI
+import CPythonInterpreter.withGil
 
 abstract class Writer[T] {
-  def write(v: T): PyValue
+  // no guarantees about references
+  def write(v: T): PyValue = withGil(PyValue.fromNew(writeNative(v)))
+
+  // always returns a PyValue that is owned by the caller and has no other references
+  // assumes that the GIL is held
+  def writeNative(v: T): Platform.Pointer = {
+    val written = write(v)
+    CPythonAPI.Py_IncRef(written.underlying)
+    written.underlying
+  }
 }
 
 object Writer extends TupleWriters with FunctionWriters {
+  def withErrorCheck[T](t: => T): T = {
+    val res = t
+    CPythonInterpreter.throwErrorIfOccured()
+    res
+  }
+
   implicit def anyWriter[T <: py.Any]: Writer[T] = new Writer[T] {
-    override def write(v: T): PyValue = v.value
+    override def writeNative(v: T): Platform.Pointer = withErrorCheck {
+      CPythonAPI.Py_IncRef(v.value.underlying)
+      v.value.underlying
+    }
   }
 
   implicit def unionWriter[A, B](implicit aClass: ClassTag[A], bClass: ClassTag[B], aWriter: Writer[A], bWriter: Writer[B]): Writer[A | B] = new Writer[A | B] {
-    override def write(v: A | B): PyValue = {
+    override def writeNative(v: A | B): Platform.Pointer = {
       aClass.unapply(v.value) match {
-        case Some(a) => aWriter.write(a)
-        case _ => bWriter.write(v.value.asInstanceOf[B])
+        case Some(a) => aWriter.writeNative(a)
+        case _ => bWriter.writeNative(v.value.asInstanceOf[B])
       }
     }
   }
 
   implicit val unitWriter: Writer[Unit] = new Writer[Unit] {
-    override def write(v: Unit): PyValue = CPythonInterpreter.noneValue
+    override def writeNative(v: Unit): Platform.Pointer = withErrorCheck {
+      CPythonAPI.Py_IncRef(CPythonInterpreter.noneValue.underlying)
+      CPythonInterpreter.noneValue.underlying
+    }
   }
 
   implicit val byteWriter: Writer[Byte] = new Writer[Byte] {
-    override def write(v: Byte): PyValue = CPythonInterpreter.valueFromLong(v)
+    override def writeNative(v: Byte): Platform.Pointer = CPythonAPI.PyLong_FromLongLong(v)
   }
 
   implicit val intWriter: Writer[Int] = new Writer[Int] {
-    override def write(v: Int): PyValue = CPythonInterpreter.valueFromLong(v)
+    override def writeNative(v: Int): Platform.Pointer = CPythonAPI.PyLong_FromLongLong(v)
   }
 
   implicit val longWriter: Writer[Long] = new Writer[Long] {
-    override def write(v: Long): PyValue = CPythonInterpreter.valueFromLong(v)
+    override def writeNative(v: Long): Platform.Pointer = CPythonAPI.PyLong_FromLongLong(v)
   }
 
   implicit val doubleWriter: Writer[Double] = new Writer[Double] {
-    override def write(v: Double): PyValue = CPythonInterpreter.valueFromDouble(v)
+    override def writeNative(v: Double): Platform.Pointer = CPythonAPI.PyFloat_FromDouble(v)
   }
 
   implicit val floatWriter: Writer[Float] = new Writer[Float] {
-    override def write(v: Float): PyValue = CPythonInterpreter.valueFromDouble(v)
+    override def writeNative(v: Float): Platform.Pointer = CPythonAPI.PyFloat_FromDouble(v)
   }
 
   implicit val booleanWriter: Writer[Boolean] = new Writer[Boolean] {
-    override def write(v: Boolean): PyValue = CPythonInterpreter.valueFromBoolean(v)
+    override def writeNative(v: Boolean): Platform.Pointer = CPythonAPI.PyBool_FromLong(Platform.intToCLong(if (v) 1 else 0))
   }
 
   implicit val stringWriter: Writer[String] = new Writer[String] {
-    override def write(v: String): PyValue = CPythonInterpreter.valueFromString(v)
+    override def writeNative(v: String): Platform.Pointer = CPythonInterpreter.toNewString(v)
   }
 
   implicit def mapWriter[K, V](implicit kWriter: Writer[K], vWriter: Writer[V]) = new Writer[Map[K, V]] {
     override def write(map: Map[K, V]): PyValue = {
       val obj = CPythonInterpreter.newDictionary()
       map.foreach { case (k, v) =>
-        CPythonInterpreter.updateBracket(obj, py.Any.from(k).value, py.Any.from(v).value)
+        CPythonInterpreter.updateBracket(obj, kWriter.write(k), vWriter.write(v))
       }
 
       obj

--- a/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Writer.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Writer.scala
@@ -24,14 +24,8 @@ abstract class Writer[T] {
 }
 
 object Writer extends TupleWriters with FunctionWriters {
-  def withErrorCheck[T](t: => T): T = {
-    val res = t
-    CPythonInterpreter.throwErrorIfOccured()
-    res
-  }
-
   implicit def anyWriter[T <: py.Any]: Writer[T] = new Writer[T] {
-    override def writeNative(v: T): Platform.Pointer = withErrorCheck {
+    override def writeNative(v: T): Platform.Pointer = {
       CPythonAPI.Py_IncRef(v.value.underlying)
       v.value.underlying
     }
@@ -47,7 +41,7 @@ object Writer extends TupleWriters with FunctionWriters {
   }
 
   implicit val unitWriter: Writer[Unit] = new Writer[Unit] {
-    override def writeNative(v: Unit): Platform.Pointer = withErrorCheck {
+    override def writeNative(v: Unit): Platform.Pointer = {
       CPythonAPI.Py_IncRef(CPythonInterpreter.noneValue.underlying)
       CPythonInterpreter.noneValue.underlying
     }

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
@@ -1,5 +1,8 @@
 package me.shadaj.scalapy.py
 
+import scala.collection.immutable
+import scala.collection.mutable
+
 import org.scalatest.funsuite.AnyFunSuite
 
 class ReaderTest extends AnyFunSuite {
@@ -89,6 +92,26 @@ class ReaderTest extends AnyFunSuite {
     local {
       val arr = py"'abc'"
       assert(arr.as[Seq[Char]] == Seq('a', 'b', 'c'))
+    }
+  }
+
+  test("Reading as a mutable sequence lets us observe mutations") {
+    local {
+      val list = py"[1, 2, 3]"
+      val readSeq = list.as[mutable.Seq[Int]]
+      assert(readSeq.toSeq == Seq(1, 2, 3))
+      list.bracketUpdate(2, 100)
+      assert(readSeq.toSeq == Seq(1, 2, 100))
+    }
+  }
+
+  test("Reading as an immutable sequence doesn't let us observe mutations") {
+    local {
+      val list = py"[1, 2, 3]"
+      val readSeq = list.as[immutable.Seq[Int]]
+      assert(readSeq.toSeq == Seq(1, 2, 3))
+      list.bracketUpdate(2, 100)
+      assert(readSeq.toSeq == Seq(1, 2, 3))
     }
   }
 

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
@@ -94,13 +94,15 @@ class ReaderTest extends AnyFunSuite {
     }
   }
 
-  test("Reading as a mutable sequence lets us observe mutations") {
+  test("Reading as a mutable sequence lets us observe mutations and edit the sequence") {
     local {
       val list = py"[1, 2, 3]"
       val readSeq = list.as[mutable.Seq[Int]]
       assert(readSeq.toSeq == Seq(1, 2, 3))
       list.bracketUpdate(2, 100)
       assert(readSeq.toSeq == Seq(1, 2, 100))
+      readSeq(1) = 100
+      assert(list.bracketAccess(1).as[Int] == 100)
     }
   }
 

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/ReaderTest.scala
@@ -1,6 +1,5 @@
 package me.shadaj.scalapy.py
 
-import scala.collection.immutable
 import scala.collection.mutable
 
 import org.scalatest.funsuite.AnyFunSuite
@@ -108,7 +107,7 @@ class ReaderTest extends AnyFunSuite {
   test("Reading as an immutable sequence doesn't let us observe mutations") {
     local {
       val list = py"[1, 2, 3]"
-      val readSeq = list.as[immutable.Seq[Int]]
+      val readSeq = list.as[Seq[Int]]
       assert(readSeq.toSeq == Seq(1, 2, 3))
       list.bracketUpdate(2, 100)
       assert(readSeq.toSeq == Seq(1, 2, 3))

--- a/docs/interacting-with-python.md
+++ b/docs/interacting-with-python.md
@@ -58,12 +58,25 @@ mySeqToProxy(2) = 100
 println(py.Dynamic.global.list(myProxy))
 ```
 
-To convert Python values back into their Scala equivalents, ScalaPy comes with the `.as` API to automatically perform conversions for supported types (those that have a `Reader` implementation). Unlike writing, where there were multiple options for converting sequence types, there is a single `.as[Seq[...]]` API for converting back that always loads the data as a proxy. If you want a full copy that can be read from many times by Scala code, you can convert the sequence into a local value with `.toVector`, `.toList`, and similar collection APIs.
+To convert Python values back into their Scala equivalents, ScalaPy comes with the `.as` API to automatically perform conversions for supported types (those that have a `Reader` implementation). Unlike writing, where there were multiple options for converting sequence types, there is a single `.as[]` API for converting back. If you load a collection into an immutable Scala sequence type, it will be loaded as a copy. If you load it as a `mutable.Seq`, however, it will be loaded as a proxy and can observe underlying changes
 
 ```scala mdoc
+import scala.collection.mutable
 val myPythonList = py.Dynamic.global.list(py.Dynamic.global.range(10))
-val backToScala = myPythonList.as[Seq[Int]]
-val scalaCopy = backToScala.toVector
+val copyLoad = myPythonList.as[Vector[Int]]
+val proxyLoad = myPythonList.as[mutable.Seq[Int]]
+
+println(copyLoad)
+println(proxyLoad)
+
+myPythonList.bracketUpdate(0, 100)
+
+println(copyLoad)
+println(proxyLoad)
+
+proxyLoad(0) = 200
+
+println(myPythonList)
 ```
 
 ## Custom Python Snippets


### PR DESCRIPTION
before:

name | size | jvm | scala-native | bytes | gb/s (jvm) | gb/s (scala native) | mb/s (jvm) | mb/s (scala native)
-- | -- | -- | -- | -- | -- | -- | -- | --
CreatePythonCopyBenchmark | 2 | 17643 | 3917 | 16 | 0.000906875248 | 0.004084758744 | 0.906875248 | 4.084758744
CreatePythonCopyBenchmark | 4 | 19567 | 4408 | 32 | 0.001635406552 | 0.007259528131 | 1.635406552 | 7.259528131
CreatePythonCopyBenchmark | 8 | 28183 | 4388 | 64 | 0.002270872512 | 0.01458523245 | 2.270872512 | 14.58523245
CreatePythonCopyBenchmark | 16 | 37590 | 7174 | 128 | 0.003405160947 | 0.01784220797 | 3.405160947 | 17.84220797
CreatePythonCopyBenchmark | 32 | 61414 | 10920 | 256 | 0.004168430651 | 0.02344322344 | 4.168430651 | 23.44322344
CreatePythonCopyBenchmark | 64 | 185467 | 14617 | 512 | 0.002760598921 | 0.03502770746 | 2.760598921 | 35.02770746
CreatePythonCopyBenchmark | 128 | 325839.5 | 25498 | 1024 | 0.00314265152 | 0.04016001255 | 3.14265152 | 40.16001255
CreatePythonCopyBenchmark | 256 | 653232 | 49453 | 2048 | 0.00313518015 | 0.04141305886 | 3.13518015 | 41.41305886
CreatePythonCopyBenchmark | 512 | 1336270 | 97473 | 4096 | 0.00306524879 | 0.04202189324 | 3.06524879 | 42.02189324

all larger sizes OOM-ed on JVM

after:

name | size | jvm | scala-native | bytes | gb/s (jvm) | gb/s (scala native) | mb/s (jvm) | mb/s (scala native)
-- | -- | -- | -- | -- | -- | -- | -- | --
CreatePythonCopyBenchmark | 2 | 16040 | 3096 | 16 | 0.0009975062344 | 0.005167958656 | 0.9975062344 | 5.167958656
CreatePythonCopyBenchmark | 4 | 17032 | 3206 | 32 | 0.001878816346 | 0.00998128509 | 1.878816346 | 9.98128509
CreatePythonCopyBenchmark | 8 | 19226 | 3396 | 64 | 0.003328825549 | 0.01884570082 | 3.328825549 | 18.84570082
CreatePythonCopyBenchmark | 16 | 23354 | 3787 | 128 | 0.00548085981 | 0.03379984156 | 5.48085981 | 33.79984156
CreatePythonCopyBenchmark | 32 | 31448 | 4549 | 256 | 0.008140422284 | 0.05627610464 | 8.140422284 | 56.27610464
CreatePythonCopyBenchmark | 64 | 48501 | 6021 | 512 | 0.01055648337 | 0.08503570835 | 10.55648337 | 85.03570835
CreatePythonCopyBenchmark | 128 | 84919 | 9568 | 1024 | 0.01205854991 | 0.1070234114 | 12.05854991 | 107.0234114
CreatePythonCopyBenchmark | 256 | 153758 | 17102 | 2048 | 0.01331963215 | 0.1197520758 | 13.31963215 | 119.7520758
CreatePythonCopyBenchmark | 512 | 300012 | 31790 | 4096 | 0.01365278722 | 0.1288455489 | 13.65278722 | 128.8455489
CreatePythonCopyBenchmark | 1024 | 589314 | 61324 | 8192 | 0.01390090851 | 0.1335855456 | 13.90090851 | 133.5855456
CreatePythonCopyBenchmark | 2048 | 1027259 | 120525 | 16384 | 0.01594923968 | 0.1359386019 | 15.94923968 | 135.9386019
CreatePythonCopyBenchmark | 4096 | 1979287 | 241682 | 32768 | 0.01655545659 | 0.1355831216 | 16.55545659 | 135.5831216
CreatePythonCopyBenchmark | 8192 | 3914671 | 486761 | 65536 | 0.01674112588 | 0.1346369163 | 16.74112588 | 134.6369163
CreatePythonCopyBenchmark | 16384 | 7881642 | 1020505.5 | 131072 | 0.01663003724 | 0.1284383083 | 16.63003724 | 128.4383083
