### PR TITLE
Optimize sequence readers by avoiding PyValue wrappers when possible

### DIFF
--- a/bench/src/main/scala/SumPythonCopyBenchmark.scala
+++ b/bench/src/main/scala/SumPythonCopyBenchmark.scala
@@ -1,6 +1,7 @@
 import me.shadaj.scalapy.py
 import me.shadaj.scalapy.interpreter.PyValue
 import me.shadaj.scalapy.py.SeqConverters
+import scala.collection.immutable
 
 object SumPythonCopyBenchmark extends communitybench.Benchmark {
   PyValue.disableAllocationWarning()
@@ -8,12 +9,12 @@ object SumPythonCopyBenchmark extends communitybench.Benchmark {
   var pythonSeq: py.Any = null
 
   def run(input: String): Double = py.local {
-    val backToScala = pythonSeq.as[Seq[Double]]
+    val backToScala = pythonSeq.as[immutable.ArraySeq[Double]]
     backToScala.sum
   }
 
   override def main(args: Array[String]): Unit = {
-    val values = Vector.fill(args.last.toInt)(math.random)
+    val values = Array.fill(args.last.toInt)(math.random)
     pythonSeq = values.toPythonCopy
     super.main(args.init)
   }

--- a/bench/src/main/scala/SumPythonProxyBenchmark.scala
+++ b/bench/src/main/scala/SumPythonProxyBenchmark.scala
@@ -13,7 +13,7 @@ object SumPythonProxyBenchmark extends communitybench.Benchmark {
   }
 
   override def main(args: Array[String]): Unit = {
-    val values = Vector.fill(args.last.toInt)(math.random)
+    val values = Array.fill(args.last.toInt)(math.random)
     pythonSeq = values.toPythonProxy
     super.main(args.init)
   }


### PR DESCRIPTION
Partially fixes #158

Before:
name | size | jvm | scala-native | bytes | gb/s (jvm) | gb/s (scala native) | mb/s (jvm) | mb/s (scala native)
-- | -- | -- | -- | -- | -- | -- | -- | --
SumPythonCopyBenchmark | 2 | 10740 | 1002 | 16 | 0.001489757914 | 0.01596806387 | 1.489757914 | 15.96806387
SumPythonCopyBenchmark | 4 | 13575 | 1483 | 32 | 0.002357274401 | 0.02157788267 | 2.357274401 | 21.57788267
SumPythonCopyBenchmark | 8 | 20979 | 2434 | 64 | 0.003050669717 | 0.02629416598 | 3.050669717 | 26.29416598
SumPythonCopyBenchmark | 16 | 34875 | 4359 | 128 | 0.003670250896 | 0.02936453315 | 3.670250896 | 29.36453315
SumPythonCopyBenchmark | 32 | 64841 | 8055 | 256 | 0.003948119246 | 0.03178150217 | 3.948119246 | 31.78150217
SumPythonCopyBenchmark | 64 | 185508 | 15559 | 512 | 0.002759988788 | 0.03290699916 | 2.759988788 | 32.90699916
SumPythonCopyBenchmark | 128 | 357038 | 29706 | 1024 | 0.002868042057 | 0.03447115061 | 2.868042057 | 34.47115061
SumPythonCopyBenchmark | 256 | 681204 | 58640 | 2048 | 0.003006441536 | 0.03492496589 | 3.006441536 | 34.92496589
SumPythonCopyBenchmark | 512 | 1381554 | 118532 | 4096 | 0.002964777345 | 0.03455606925 | 2.964777345 | 34.55606925
SumPythonCopyBenchmark | 1024 | 2784087.5 | 239789 | 8192 | 0.002942436256 | 0.03416336863 | 2.942436256 | 34.16336863
SumPythonCopyBenchmark | 2048 | 7047426 | 480481 | 16384 | 0.002324820438 | 0.03409916313 | 2.324820438 | 34.09916313
SumPythonCopyBenchmark | 4096 | 14850101.5 | 1006296.5 | 32768 | 0.002206584245 | 0.03256296728 | 2.206584245 | 32.56296728
SumPythonCopyBenchmark | 8192 | 31025853.5 | 2057867.5 | 65536 | 0.00211230289 | 0.03184655961 | 2.11230289 | 31.84655961
SumPythonCopyBenchmark | 16384 | 60113323 | 4118450 | 131072 | 0.002180415147 | 0.03182556544 | 2.180415147 | 31.82556544

After:
name | size | jvm | scala-native | bytes | gb/s (jvm) | gb/s (scala native) | mb/s (jvm) | mb/s (scala native)
-- | -- | -- | -- | -- | -- | -- | -- | --
SumPythonCopyBenchmark | 2 | 6412 | 1262 | 16 | 0.002495321273 | 0.01267828843 | 2.495321273 | 12.67828843
SumPythonCopyBenchmark | 4 | 7905 | 1433 | 32 | 0.004048070841 | 0.0223307746 | 4.048070841 | 22.3307746
SumPythonCopyBenchmark | 8 | 11372 | 1784 | 64 | 0.005627857897 | 0.03587443946 | 5.627857897 | 35.87443946
SumPythonCopyBenchmark | 16 | 17974 | 2515 | 128 | 0.007121397574 | 0.05089463221 | 7.121397574 | 50.89463221
SumPythonCopyBenchmark | 32 | 32160 | 4459 | 256 | 0.007960199005 | 0.05741197578 | 7.960199005 | 57.41197578
SumPythonCopyBenchmark | 64 | 59401.5 | 7284 | 512 | 0.00861931096 | 0.07029104887 | 8.61931096 | 70.29104887
SumPythonCopyBenchmark | 128 | 113963 | 12874 | 1024 | 0.008985372445 | 0.07954015846 | 8.985372445 | 79.54015846
SumPythonCopyBenchmark | 256 | 219400 | 24706 | 2048 | 0.009334548769 | 0.08289484336 | 9.334548769 | 82.89484336
SumPythonCopyBenchmark | 512 | 433380 | 48791 | 4096 | 0.009451289861 | 0.08394990879 | 9.451289861 | 83.94990879
SumPythonCopyBenchmark | 1024 | 859167 | 93765 | 8192 | 0.009534816863 | 0.08736735456 | 9.534816863 | 87.36735456
SumPythonCopyBenchmark | 2048 | 1711845.5 | 189474 | 16384 | 0.009570957192 | 0.08647096699 | 9.570957192 | 86.47096699
SumPythonCopyBenchmark | 4096 | 3411042.5 | 376354 | 32768 | 0.009606447296 | 0.08706696355 | 9.606447296 | 87.06696355
SumPythonCopyBenchmark | 8192 | 6879425 | 755493 | 65536 | 0.009526377568 | 0.08674600559 | 9.526377568 | 86.74600559
SumPythonCopyBenchmark | 16384 | 13817777 | 1506097 | 131072 | 0.009485751579 | 0.08702759517 | 9.485751579 | 87.02759517