### PR TITLE
Enable setting version of python lib via system property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## vNEXT
+### Highlights :tada:
++ The version of the Python native library can now be controlled with the `scalapy.python.library` system property
 
 ## v0.5.0
 ### Highlights :tada:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## vNEXT
 ### Highlights :tada:
 + Add support for bracket syntax to facades. The annotation `@PyBracketAccess` can be used on methods to mark them as representing bracket access on an object. The target method must have one (to read the value) or two parameters (to update the value) ([PR #194](https://github.com/shadaj/scalapy/pull/194)).
-+ The version of the Python native library can now be controlled with the `scalapy.python.library` system property
++ The version of the Python native library can now be controlled with the `scalapy.python.library` system property ([PR #198](https://github.com/shadaj/scalapy/pull/198))
 
 ## v0.5.0
 ### Highlights :tada:

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -8,9 +8,8 @@ import scala.util.{Success, Failure, Properties}
 
 class CPythonAPIInterface {
   val pythonLibrariesToTry =
-    sys.env
-      .get("SCALAPY_PYTHON_LIBRARY")
-      .orElse(Properties.propOrNone("scalapy.python.library"))
+    Properties.propOrNone("scalapy.python.library")
+      .orElse(sys.env.get("SCALAPY_PYTHON_LIBRARY"))
       .toSeq ++
       Seq(
         "python3",

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -4,11 +4,14 @@ import scala.sys
 import scala.util.Try
 
 import com.sun.jna.{Native, NativeLong, Memory}
-import scala.util.{Success, Failure}
+import scala.util.{Success, Failure, Properties}
 
 class CPythonAPIInterface {
   val pythonLibrariesToTry =
-    sys.env.get("SCALAPY_PYTHON_LIBRARY").toSeq ++
+    sys.env
+      .get("SCALAPY_PYTHON_LIBRARY")
+      .orElse(Properties.propOrNone("scalapy.python.library"))
+      .toSeq ++
       Seq(
         "python3",
         "python3.7", "python3.7m",
@@ -22,7 +25,7 @@ class CPythonAPIInterface {
   } catch {
     case t: Throwable => Failure(t)
   })
-  
+
   loadAttempts.find(_.isSuccess).getOrElse {
     loadAttempts.foreach(_.failed.get.printStackTrace())
     throw new Exception(s"Unable to locate Python library, tried ${pythonLibrariesToTry.mkString(", ")}")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,3 +80,5 @@ or set the system property `scalapy.python.library`
 ```shell
 sbt -Dscalapy.python.library=python3.8 run
 ```
+
+The system property takes precedence over the environment variable.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,11 +66,17 @@ To convert Python values back into Scala, we use the `.as` method and pass in th
 val listLength = listLengthPython.as[Int]
 ```
 ## Execution
-ScalaPy officially supports Python 3.{7, 8, 9}. If you want to use another version of Python, you should define the environment variable `SCALAPY_PYTHON_LIBRARY`
+ScalaPy officially supports Python 3.{7, 8, 9}. If you want to use another version of Python, you should either define the environment variable `SCALAPY_PYTHON_LIBRARY`
 
 ```shell
 python --version
 # Python 3.8.6
 export SCALAPY_PYTHON_LIBRARY=python3.8
 sbt run
+```
+
+or set the system property `scalapy.python.library`
+
+```shell
+sbt -Dscalapy.python.library=python3.8 run
 ```


### PR DESCRIPTION
in order to facilitate automatic setting up ScalaPy since it much easier to set a system property than to set an environment variable in Scala.