### PR TITLE
Set python executable prior to initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ website/node_modules
 lowered.hnir
 .vscode/
 facadeGen/.mypy_cache
+.metals/
+.bsp/
+.bloop/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Highlights :tada:
 + Add support for bracket syntax to facades. The annotation `@PyBracketAccess` can be used on methods to mark them as representing bracket access on an object. The target method must have one (to read the value) or two parameters (to update the value) ([PR #194](https://github.com/shadaj/scalapy/pull/194)).
 + The version of the Python native library can now be controlled with the `scalapy.python.library` system property ([PR #198](https://github.com/shadaj/scalapy/pull/198))
-+ Enable running `Py_SetProgramName` with user provided input prior to `Py_Initialize` to set the correct paths to Python run-time libraries. Input to `Py_SetProgramName`, the Python interpreter executable, can be controlled with the `scalapy.python.programname` system property (JVM) and the `SCALAPY_PYTHON_PROGRAMNAME` environment variable (JVM and Scala Native) ([PR #200](https://github.com/shadaj/scalapy/pull/200))
++ Enable running `Py_SetProgramName` with user provided input prior to `Py_Initialize` to set the correct paths to Python run-time libraries. Input to `Py_SetProgramName`, the Python interpreter executable, can be controlled with either the `scalapy.python.programname` system property or the `SCALAPY_PYTHON_PROGRAMNAME` environment variable ([PR #200](https://github.com/shadaj/scalapy/pull/200))
 
 ## v0.5.0
 ### Highlights :tada:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Highlights :tada:
 + Add support for bracket syntax to facades. The annotation `@PyBracketAccess` can be used on methods to mark them as representing bracket access on an object. The target method must have one (to read the value) or two parameters (to update the value) ([PR #194](https://github.com/shadaj/scalapy/pull/194)).
 + The version of the Python native library can now be controlled with the `scalapy.python.library` system property ([PR #198](https://github.com/shadaj/scalapy/pull/198))
++ Enable running `Py_SetProgramName` with user provided input prior to `Py_Initialize` to set the correct paths to Python run-time libraries. Input to `Py_SetProgramName`, the Python interpreter executable, can be controlled with the `scalapy.python.programname` system property (JVM) and the `SCALAPY_PYTHON_PROGRAMNAME` environment variable (JVM and Scala Native) ([PR #200](https://github.com/shadaj/scalapy/pull/200))
 
 ## v0.5.0
 ### Highlights :tada:

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -8,8 +8,8 @@ import scala.util.{Success, Failure, Properties}
 
 class CPythonAPIInterface {
   val pythonLibrariesToTry =
-    Properties.propOrNone("scalapy.python.library")
-      .orElse(sys.env.get("SCALAPY_PYTHON_LIBRARY"))
+    Option(System.getenv("SCALAPY_PYTHON_LIBRARY"))
+      .orElse(Properties.propOrNone("scalapy.python.library"))
       .toSeq ++
       Seq(
         "python3",

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -35,6 +35,8 @@ class CPythonAPIInterface {
 
   @scala.native def Py_DecodeLocale(str: String, size: Platform.Pointer): WString
 
+  @scala.native def PyMem_RawFree(p: Platform.Pointer): Unit
+
   @scala.native def PyEval_SaveThread(): Platform.Pointer
   @scala.native def PyGILState_Ensure(): Int
   @scala.native def PyGILState_Release(state: Int): Unit

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -33,6 +33,8 @@ class CPythonAPIInterface {
   @scala.native def Py_SetProgramName(str: WString): Unit
   @scala.native def Py_Initialize(): Unit
 
+  @scala.native def Py_DecodeLocale(str: String, size: Platform.Pointer): WString
+
   @scala.native def PyEval_SaveThread(): Platform.Pointer
   @scala.native def PyGILState_Ensure(): Int
   @scala.native def PyGILState_Release(state: Int): Unit

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -3,7 +3,7 @@ package me.shadaj.scalapy.interpreter
 import scala.sys
 import scala.util.Try
 
-import com.sun.jna.{Native, NativeLong, Memory}
+import com.sun.jna.{Native, NativeLong, Memory, WString}
 import scala.util.{Success, Failure, Properties}
 
 class CPythonAPIInterface {
@@ -30,6 +30,7 @@ class CPythonAPIInterface {
     throw new Exception(s"Unable to locate Python library, tried ${pythonLibrariesToTry.mkString(", ")}")
   }
 
+  @scala.native def Py_SetProgramName(str: WString): Unit
   @scala.native def Py_Initialize(): Unit
 
   @scala.native def PyEval_SaveThread(): Platform.Pointer

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -3,6 +3,8 @@ package me.shadaj.scalapy.interpreter
 import com.sun.jna
 import com.sun.jna.Native
 import java.nio.charset.Charset
+import scala.sys
+import scala.util.Properties
 
 object Platform {
   final val isNative = false
@@ -17,6 +19,7 @@ object Platform {
 
   val emptyCString: CString = ""
 
+  type CWideString = jna.WString
   type CString = String
   type Pointer = jna.Pointer
   type PointerToPointer = jna.Pointer
@@ -79,4 +82,8 @@ object Platform {
   def setPtrLong(ptr: Pointer, offset: Int, value: Long): Unit = ptr.setLong(offset, value)
   def setPtrInt(ptr: Pointer, offset: Int, value: Int): Unit = ptr.setInt(offset, value)
   def setPtrByte(ptr: Pointer, offset: Int, value: Byte): Unit = ptr.setByte(offset, value)
+
+  def programName: Option[CWideString] =
+    Properties.propOrNone("scalapy.python.programname").map(new CWideString(_))
+
 }

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -19,7 +19,6 @@ object Platform {
 
   val emptyCString: CString = ""
 
-  type CWideString = jna.WString
   type CString = String
   type Pointer = jna.Pointer
   type PointerToPointer = jna.Pointer
@@ -83,7 +82,8 @@ object Platform {
   def setPtrInt(ptr: Pointer, offset: Int, value: Int): Unit = ptr.setInt(offset, value)
   def setPtrByte(ptr: Pointer, offset: Int, value: Byte): Unit = ptr.setByte(offset, value)
 
-  def programName: Option[CWideString] =
-    Properties.propOrNone("scalapy.python.programname").map(new CWideString(_))
-
+  def programName: Option[jna.WString] =
+    Properties.propOrNone("scalapy.python.programname")
+      .orElse(sys.env.get("SCALAPY_PYTHON_PROGRAMNAME"))
+      .map(new jna.WString(_))
 }

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -3,8 +3,6 @@ package me.shadaj.scalapy.interpreter
 import com.sun.jna
 import com.sun.jna.Native
 import java.nio.charset.Charset
-import scala.sys
-import scala.util.Properties
 
 object Platform {
   final val isNative = false
@@ -82,8 +80,5 @@ object Platform {
   def setPtrInt(ptr: Pointer, offset: Int, value: Int): Unit = ptr.setInt(offset, value)
   def setPtrByte(ptr: Pointer, offset: Int, value: Byte): Unit = ptr.setByte(offset, value)
 
-  def programName: Option[jna.WString] =
-    Properties.propOrNone("scalapy.python.programname")
-      .orElse(sys.env.get("SCALAPY_PYTHON_PROGRAMNAME"))
-      .map(new jna.WString(_))
+  def toCWideString[T](str: String)(fn: jna.WString => T): T = fn(new jna.WString(str))
 }

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -4,6 +4,7 @@ import scala.scalanative.unsafe._
 
 @extern
 object CPythonAPI {
+  def Py_SetProgramName(str: Platform.CWideString): Unit = extern
   def Py_Initialize(): Unit = extern
 
   def PyEval_SaveThread(): Platform.Pointer = extern
@@ -24,7 +25,7 @@ object CPythonAPI {
   def PyNumber_Multiply(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer = extern
   def PyNumber_TrueDivide(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer = extern
   def PyNumber_Remainder(o1: Platform.Pointer, o2: Platform.Pointer): Platform.Pointer = extern
-  
+
   def PyLong_FromLongLong(long: CLongLong): Platform.Pointer = extern
   def PyLong_AsLong(pyLong: Platform.Pointer): CLong = extern
   def PyLong_AsLongLong(pyLong: Platform.Pointer): CLongLong = extern

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -4,8 +4,10 @@ import scala.scalanative.unsafe._
 
 @extern
 object CPythonAPI {
-  def Py_SetProgramName(str: Platform.CWideString): Unit = extern
+  def Py_SetProgramName(str: Ptr[CWideChar]): Unit = extern
   def Py_Initialize(): Unit = extern
+
+  def Py_DecodeLocale(str: CString, size: Ptr[CSize]): Ptr[CWideChar] = extern
 
   def PyEval_SaveThread(): Platform.Pointer = extern
   def PyGILState_Ensure(): Int = extern

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -9,6 +9,8 @@ object CPythonAPI {
 
   def Py_DecodeLocale(str: CString, size: Ptr[CSize]): Ptr[CWideChar] = extern
 
+  def PyMem_RawFree(p: Platform.Pointer): Unit = extern
+
   def PyEval_SaveThread(): Platform.Pointer = extern
   def PyGILState_Ensure(): Int = extern
   def PyGILState_Release(state: Int): Unit = extern

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -10,6 +10,7 @@ import scala.scalanative.runtime.Intrinsics
 import scala.scalanative.unsigned._
 
 import scala.sys
+import scala.util.Properties
 
 object Platform {
   final val isNative = true
@@ -61,7 +62,9 @@ object Platform {
   def setPtrByte(ptr: Pointer, offset: Int, value: Byte): Unit = !((ptr + offset)).asInstanceOf[Ptr[Byte]] = value
 
   def programName: Option[Ptr[CWideChar]] =
-    sys.env.get("SCALAPY_PYTHON_PROGRAMNAME").map(toCWideString(_))
+    Properties.propOrNone("scalapy.python.programname")
+      .orElse(sys.env.get("SCALAPY_PYTHON_PROGRAMNAME"))
+      .map(toCWideString(_))
 
   private def toCWideString(str: String): Ptr[CWideChar] =
     CPythonAPI.Py_DecodeLocale(Zone(implicit zone => toCString(str)), null)

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -22,6 +22,8 @@ object Platform {
 
   val emptyCString: CString = c""
 
+  // FIXME: use sn.CWideString in the next Scala Native release
+  type CWideString = Ptr[sn.CWideChar]
   type CString = sn.CString
   type Pointer = Ptr[Byte]
   type PointerToPointer = Ptr[Ptr[Byte]]
@@ -57,4 +59,6 @@ object Platform {
   def setPtrLong(ptr: Pointer, offset: Int, value: Long): Unit = !((ptr + offset)).asInstanceOf[Ptr[Long]] = value
   def setPtrInt(ptr: Pointer, offset: Int, value: Int): Unit = !((ptr + offset)).asInstanceOf[Ptr[Int]] = value
   def setPtrByte(ptr: Pointer, offset: Int, value: Byte): Unit = !((ptr + offset)).asInstanceOf[Ptr[Byte]] = value
+
+  def programName: Option[CWideString] = None
 }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
@@ -6,6 +6,7 @@ import me.shadaj.scalapy.py.PythonException
 import me.shadaj.scalapy.py.IndexError
 
 object CPythonInterpreter {
+  Platform.programName.foreach(CPythonAPI.Py_SetProgramName(_))
   CPythonAPI.Py_Initialize()
 
   private[scalapy] val globals: Platform.Pointer = CPythonAPI.PyDict_New()

--- a/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/interpreter/CPythonInterpreter.scala
@@ -10,8 +10,8 @@ import me.shadaj.scalapy.py.IndexError
 object CPythonInterpreter {
   private def initialize: Unit = {
     val programName =
-      Properties.propOrNone("scalapy.python.programname")
-        .orElse(sys.env.get("SCALAPY_PYTHON_PROGRAMNAME"))
+      Option(System.getenv("SCALAPY_PYTHON_PROGRAMNAME"))
+        .orElse(Properties.propOrNone("scalapy.python.programname"))
 
     programName.fold(CPythonAPI.Py_Initialize())(Platform.toCWideString(_) { programName =>
       CPythonAPI.Py_SetProgramName(programName)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,3 +82,22 @@ sbt -Dscalapy.python.library=python3.8 run
 ```
 
 The system property takes precedence over the environment variable.
+
+## Virtualenv
+
+To use ScalaPy with a Python installation inside a virtualenv, set the path to the Python interpreter executable using either the `scalapy.python.programname` system property (JVM only)
+
+```shell
+sbt -Dscalapy.python.programname=/Users/example/example-env/bin/python run
+```
+
+or the `SCALAPY_PYTHON_PROGRAMNAME` environment variable (JVM and Scala Native)
+
+```shell
+export SCALAPY_PYTHON_PROGRAMNAME=/Users/example/example-env/bin/python
+sbt run
+```
+
+The system property takes precedence over the environment variable.
+
+This variable is used as the input to the Python/C API function `Py_SetProgramName`. `Py_SetProgramName` is run prior to `Py_Initialize` to set the correct paths to Python run-time libraries (`prefix`, `exec_prefix`, ...).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,7 +81,7 @@ or set the system property `scalapy.python.library`
 sbt -Dscalapy.python.library=python3.8 run
 ```
 
-The system property takes precedence over the environment variable.
+The environment variable takes precedence over the system property.
 
 ## Virtualenv
 
@@ -98,6 +98,6 @@ export SCALAPY_PYTHON_PROGRAMNAME=/Users/example/example-env/bin/python
 sbt run
 ```
 
-The system property takes precedence over the environment variable.
+The environment variable takes precedence over the system property.
 
 This variable is used as the input to the Python/C API function `Py_SetProgramName`. `Py_SetProgramName` is run prior to `Py_Initialize` to set the correct paths to Python run-time libraries (`prefix`, `exec_prefix`, ...).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,13 +85,13 @@ The system property takes precedence over the environment variable.
 
 ## Virtualenv
 
-To use ScalaPy with a Python installation inside a virtualenv, set the path to the Python interpreter executable using either the `scalapy.python.programname` system property (JVM only)
+To use ScalaPy with a Python installation inside a virtualenv, set the path to the Python interpreter executable using either the `scalapy.python.programname` system property
 
 ```shell
 sbt -Dscalapy.python.programname=/Users/example/example-env/bin/python run
 ```
 
-or the `SCALAPY_PYTHON_PROGRAMNAME` environment variable (JVM and Scala Native)
+or the `SCALAPY_PYTHON_PROGRAMNAME` environment variable
 
 ```shell
 export SCALAPY_PYTHON_PROGRAMNAME=/Users/example/example-env/bin/python


### PR DESCRIPTION
Allow users to set the Python interpreter to be used by `Py_SetProgramName` by setting the `scalapy.python.programname` system property, at least for the jvm for now. The doc recommends running `Py_SetProgramName` prior to `Py_Initialize` so that the correct Python run-time libraries relative to the interpreter executable can be found (`prefix`, 'exec_prefix', ...)

https://docs.python.org/3/extending/embedding.html#very-high-level-embedding
https://docs.python.org/3/c-api/init.html#c.Py_SetProgramName

This enables using ScalaPy with virtualenv. Since a Python installation inside virtualenv shares the same shared library (`libpython...so`) with the base installation, without `Py_SetProgramName`, there's no way to point ScalaPy towards the runtime directories set by virtualenv.

Running `Py_SetProgramName` also prevents some weird stuff. For example, without running `Py_SetProgramName`, `sys.executable`/`Py_GetProgramFullPath` points to java instead of the Python interpreter executable.

```scala
py.module("sys").executable 
// py.Dynamic = /Library/Java/JavaVirtualMachines/adoptopenjdk-16.jdk/Contents/Home/bin/java
```

After applying this PR and set `scalapy.python.programname` to `/Users/kien/.pyenv/versions/3.8.5/envs/test_env/bin/python`

```scala
py.module("sys").executable 
// py.Dynamic = /Users/kien/.pyenv/versions/3.8.5/envs/test_env/bin/python
```