### PR TITLE
Add instructions to set up ScalaPy using python-native-libs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ libraryDependencies += "me.shadaj" %% "scalapy-core" % "0.5.0"
 libraryDependencies += "me.shadaj" %%% "scalapy-core" % "0.5.0"
 ```
 
-You'll then need to add the Python native libraries to your project and configure SBT to run your code in a separate JVM instance.
+You'll then need to add the Python native libraries to your project and configure SBT to run your code in a separate JVM instance, either manually,
 
 ```scala
 fork := true
@@ -40,10 +40,46 @@ lazy val pythonLibsDir = {
 javaOptions += s"-Djna.library.path=$pythonLibsDir"
 ```
 
+or using the [`python-native-libs`](https://github.com/kiendang/python-native-libs) helper library,
+
+First, add `python-native-libs` to `project/plugins.sbt`
+
+```scala
+libraryDependencies += "ai.kien" %% "python-native-libs" % "0.2.1"
+```
+
+Then, in `build.sbt`,
+
+```scala
+import ai.kien.python.Python
+
+lazy val python = Python("<optional-path-to-a-python-interpreter-executable>")
+
+lazy val javaOpts = python.scalapyProperties.get.map {
+  case (k, v) => s"""-D$k=$v"""
+}.toSeq
+
+javaOptions += javaOpts
+```
+
 If you'd like to use [Scala Native](https://scala-native.readthedocs.io/), follow the instructions there to create a project with Scala Native `0.4.0-M2`. Then, add the following additional configuration to your SBT build to link the Python interpreter.
+
+Manually,
 
 ```scala
 lazy val pythonLdFlags = ... // same as above
+
+nativeLinkingOptions ++= pythonLdFlags
+```
+
+Using `python-native-libs`,
+
+```scala
+import ai.kien.python.Python
+
+lazy val python = Python("<optional-path-to-a-python-interpreter-executable>")
+
+lazy val pythonLdFlags = python.ldflags.get
 
 nativeLinkingOptions ++= pythonLdFlags
 ```

--- a/docs/jupyter-notebooks.md
+++ b/docs/jupyter-notebooks.md
@@ -19,7 +19,7 @@ In your `jupyter/kernels/scala/kernel.json` file, replace the contents with
   "argv" : [
     "bash",
     "-c",
-    "env SCALAPY_PYTHON_LIBRARY=python3.6m java -Djna.library.path=/usr/lib/x86_64-linux-gnu/ -jar /usr/local/share/jupyter/kernels/scala/launcher.jar --connection-file {connection_file}"
+    "env SCALAPY_PYTHON_LIBRARY=python3.7m java -Djna.library.path=/usr/lib/x86_64-linux-gnu/ -jar /usr/local/share/jupyter/kernels/scala/launcher.jar --connection-file {connection_file}"
   ]
 }"
 ```
@@ -30,7 +30,7 @@ Make sure to replace `/usr/lib/x86_64-linux-gnu/libpython3.6m.so` with the path 
 ScalaPy on the JVM contains with all the logic to load native libraries built-in, so you can import ScalaPy and start using it as usual!
 
 ```scala
-import $ivy.`me.shadaj::scalapy:0.4.1`
+import $ivy.`me.shadaj::scalapy-core:0.5.0`
 
 import me.shadaj.scalapy.py
 ```


### PR DESCRIPTION
[`python-native-libs`](https://github.com/kiendang/python-native-libs) was made to help setting up ScalaPy more reliably. This adds instructions on how to use it to the doc.