### PR TITLE
Fix getting types of facades methods arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## vNEXT
+### Highlights :tada:
++ Fix getting types of the facades methods arguments in the `native_impl` method implementation in Scala 3. Create new test class `SpecialCasesTest` ([#237](https://github.com/shadaj/scalapy/pull/237))
 
 ## v0.5.1
 ### Highlights :tada:

--- a/core/shared/src/test/scala-3/me/shadaj/scalapy/py/SpecialCasesTest.scala
+++ b/core/shared/src/test/scala-3/me/shadaj/scalapy/py/SpecialCasesTest.scala
@@ -1,0 +1,13 @@
+package me.shadaj.scalapy.py
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class SpecialCasesTest extends AnyFunSuite {
+  test("Can apply lambda function as argument to the facade method") {
+    local {
+      val myList: Seq[Int] = Seq(1,2,3)
+      val result = module("functools").as[ReduceFacade].reduce((acc: Int, value: Int) => acc+value, myList.toPythonProxy, 0)
+      assert(result == 6)
+    }
+  }
+}

--- a/core/shared/src/test/scala-3/me/shadaj/scalapy/py/TestFacades.scala
+++ b/core/shared/src/test/scala-3/me/shadaj/scalapy/py/TestFacades.scala
@@ -21,3 +21,7 @@ import me.shadaj.scalapy.interpreter
   @PyBracketAccess
   def update(index: Int, newValue: Int): Unit = native
 }
+
+@native class ReduceFacade extends Any {
+  def reduce(lambda: (Int, Int) => Int, numbers: Any, initializer: Int): Int = native
+}

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/SpecialSyntaxTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/SpecialSyntaxTest.scala
@@ -59,4 +59,12 @@ class SpecialSyntaxTest extends AnyFunSuite {
       assert(cleaned)
     }
   }
+
+  test("Can apply function as argument to the facade method") {
+    local {
+      val myList: Seq[Int] = Seq(1,2,3)
+      val result = module("functools").as[ReduceFacade].reduce((acc: Int, value: Int) => acc+value, myList.toPythonProxy, 0)
+      assert(result == 6)
+    }
+  }
 }

--- a/core/shared/src/test/scala/me/shadaj/scalapy/py/SpecialSyntaxTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapy/py/SpecialSyntaxTest.scala
@@ -59,12 +59,4 @@ class SpecialSyntaxTest extends AnyFunSuite {
       assert(cleaned)
     }
   }
-
-  test("Can apply function as argument to the facade method") {
-    local {
-      val myList: Seq[Int] = Seq(1,2,3)
-      val result = module("functools").as[ReduceFacade].reduce((acc: Int, value: Int) => acc+value, myList.toPythonProxy, 0)
-      assert(result == 6)
-    }
-  }
 }

--- a/coreMacros/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
+++ b/coreMacros/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
@@ -91,9 +91,8 @@ object FacadeImpl {
     }
 
     def constructASTforMethodFrom(arg: quotes.reflect.Term) = {
-      val argumentType = arg.tpe.typeSymbol
-      val applyArgTypeToWriter = Helper.writerTypeRepr.appliedTo(TypeIdent(argumentType).tpe)
-      val tree = Apply(Apply(TypeApply(Ref(Helper.methodFromSymbol),List(TypeIdent(argumentType))),List(arg)),
+      val applyArgTypeToWriter = Helper.writerTypeRepr.appliedTo(arg.tpe.widen)
+      val tree = Apply(Apply(TypeApply(Ref(Helper.methodFromSymbol),List(Inferred(arg.tpe.widen))),List(arg)),
       List(searchImplicit(applyArgTypeToWriter)))
       tree
     }
@@ -183,10 +182,9 @@ object FacadeImpl {
     }
     else {
       def constructASTforMethodFrom(arg: quotes.reflect.Term) = {
-        val argumentType = arg.tpe.typeSymbol
-        val applyArgTypeToWriter = Helper.writerTypeRepr.appliedTo(TypeIdent(argumentType).tpe)
-        val tree = Apply(Apply(TypeApply(Ref(Helper.methodFromSymbol),List(TypeIdent(argumentType))),List(arg)),
-          List(searchImplicit(applyArgTypeToWriter)))
+        val applyArgTypeToWriter = Helper.writerTypeRepr.appliedTo(arg.tpe.widen)
+        val tree = Apply(Apply(TypeApply(Ref(Helper.methodFromSymbol),List(Inferred(arg.tpe.widen))),List(arg)),
+        List(searchImplicit(applyArgTypeToWriter)))
         tree
       }
 


### PR DESCRIPTION
* Fixed getting types of facades methods arguments in the `native_impl` method implementation in Scala 3
* Created new class `SpecialCasesTest` for testing such bugs