### PR TITLE
Fix pipeline and other small things

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
       - uses: actions/checkout@master
       - name: Set up JDK 1.8 and SBT

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import scala.sys.process._
 
 ThisBuild / organization := "dev.scalapy"
 
-lazy val scala212Version = "2.12.20"
-lazy val scala213Version = "2.13.14"
-lazy val scala3Version = "3.5.0"
+lazy val scala212Version = "2.12.21"
+lazy val scala213Version = "2.13.18"
+lazy val scala3Version = "3.3.7"
 lazy val supportedScalaVersions = List(scala212Version, scala213Version, scala3Version)
 
 ThisBuild / scalaVersion := scala213Version

--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,7 @@ lazy val core = crossProject(JVMPlatform, NativePlatform)
       IO.write(fileToWrite, toWrite)
       Seq(fileToWrite)
     },
-    libraryDependencies += "org.scala-lang.modules" %%% "scala-collection-compat" % "2.12.0",
+    libraryDependencies += "org.scala-lang.modules" %%% "scala-collection-compat" % "2.14.0",
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) => Seq(
@@ -177,7 +177,7 @@ lazy val core = crossProject(JVMPlatform, NativePlatform)
         case _ => Seq.empty
       }
     },
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.19" % Test,
+    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.20" % Test,
     Compile / unmanagedSourceDirectories += {
       val sharedSourceDir = (ThisBuild / baseDirectory).value / "core/shared/src/main"
       if (scalaVersion.value.startsWith("2.13.") || scalaVersion.value.startsWith("3")) sharedSourceDir / "scala-2.13"

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -10,6 +10,8 @@ class CPythonAPIInterface {
       .map(Seq(_))
       .getOrElse(Seq(
         "python3",
+        "python3.14", "python3.14m",
+        "python3.13", "python3.13m",
         "python3.12", "python3.12m",
         "python3.11", "python3.11m",
         "python3.10", "python3.10m",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,7 +104,7 @@ To convert Python values back into Scala, we use the `.as` method and pass in th
 val listLength = listLengthPython.as[Int]
 ```
 ## Execution
-ScalaPy officially supports Python 3.{7, 8, 9, 10, 11, 12}. If you want to use another version of Python, you should either define the environment variable `SCALAPY_PYTHON_LIBRARY`
+ScalaPy officially supports Python 3.{8, 9, 10, 11, 12, 13, 14}. If you want to use another version of Python, you should either define the environment variable `SCALAPY_PYTHON_LIBRARY`
 
 ```shell
 python --version

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.12.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.1.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.5")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.12")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.2")
 


### PR DESCRIPTION
Changes:

1. Remove test pipeline for Python 3.7. It has [reached its end of life](https://devguide.python.org/versions/#unsupported-versions) and is [no longer supported by github actions](https://github.com/actions/setup-python/issues/962#issuecomment-2414418045). 
2. Add support for Python 3.13 and 3.14.
3. Upgrade scala 2.12 and 2.13 to the [latest release](https://www.scala-lang.org/download/all.html). Downgrade scala3 version to the [LTS release](https://www.scala-lang.org/development/).